### PR TITLE
LivPrb can vary across Markov states

### DIFF
--- a/ConsumptionSaving/TractableBufferStockModel.py
+++ b/ConsumptionSaving/TractableBufferStockModel.py
@@ -401,8 +401,8 @@ if __name__ == '__main__':
                             "aXtraMax":ExampleType.mUpperBnd, # Maximum value of assets above minimum in grid
                             "aXtraCount":48,      # Number of points in assets grid
                             "aXtraExtra":[None],  # Additional points to include in assets grid
-                            "exp_nest":3,         # Degree of exponential nesting when constructing assets grid
-                            "LivPrb":[1.0],       # Survival probability
+                            "aXtraNestFac":3,     # Degree of exponential nesting when constructing assets grid
+                            "LivPrb":[np.array([1.0,1.0])], # Survival probability
                             "DiscFac":base_primitives['DiscFac'], # Intertemporal discount factor
                             'Nagents':1,          # Number of agents in a simulation (irrelevant)
                             'tax_rate':0.0,       # Tax rate on labor income (irrelevant)


### PR DESCRIPTION
Updated the Markov model to allow the survival probability LivPrb to
vary between discrete Markov states.  This is useful for having states
represent discrete health levels (so that someone in poor health is more
likely to die than someone in good health).

Moreover, it's a back-door route to do the Krussell-Smith model of
infinitely lived dynastic agents who occasionally change their discount
factor due to a generational change (DiscFac --> 1.0, LivPrb substitutes
for DiscFac).  Must turn off mortality in simulation for this to work.