### PR TITLE
Check Rboro is greater than Rsave for kinky consumers

### DIFF
--- a/ConsumptionSaving/ConsIndShockModel.py
+++ b/ConsumptionSaving/ConsIndShockModel.py
@@ -1411,6 +1411,8 @@ def solveConsKinkedR(solution_next,IncomeDstn,LivPrb,DiscFac,CRRA,Rboro,Rsave,
         and MPCmax.  It might also have a value function vFunc.
     '''
     assert Rboro>=Rsave, 'Interest factor on debt less than interest factor on savings!'    
+    assert Rboro>Rsave, 'Interest factor on debt is equal to interest factor on savings, ' \
+                         'the model without kinks is best suited for that case.'
     
     solver = ConsKinkedRsolver(solution_next,IncomeDstn,LivPrb,
                                             DiscFac,CRRA,Rboro,Rsave,PermGroFac,BoroCnstArt,


### PR DESCRIPTION
The solution to the kinky consumer behaves weird when Rboro=Rsave. For example, in ‘ConsumerParameters.py’ set both rates equal to 1.02, then run ‘ConsIndShockModel.py’ and look at the (kinky) consumption function plotted.
The fix tells the user that when Rboro=Rsave, it is better to use the model without kinks. The fix is introduced in the function ‘solveConsKinkedR’, immediately after the code checks that Rboro>=Rsave. This fixes #100 