### PR TITLE
Tiny fix to decay interpolation in linear interpolation 

### DIFF
--- a/HARKinterpolation.py
+++ b/HARKinterpolation.py
@@ -690,7 +690,7 @@ class LinearInterp(HARKinterpolator1D):
         
         if self.decay_extrap:
             above_upper_bound = x > self.x_list[-1]
-            x_temp = x[above_upper_bound] - self.function.x_list[-1]
+            x_temp = x[above_upper_bound] - self.x_list[-1]
 
             if _eval:
                 y[above_upper_bound] = self.intercept_limit + \


### PR DESCRIPTION
Changed one line of code in HARKinterpolation.py, in  the calculation of x_temp in the _evalOrDer method of LinearInterp.  Previous code didn't work.

This should be a super simple PR.  Let me know if not.