### PR TITLE
Remove (some) unused imports

### DIFF
--- a/ConsumptionSaving/ConsIndShockModel-Demos/Try-Alternative-Parameter-Values.py
+++ b/ConsumptionSaving/ConsIndShockModel-Demos/Try-Alternative-Parameter-Values.py
@@ -19,7 +19,6 @@ mMaxVal = 5. # maximum value of the consumer's cash-on-hand to show in plots
 import ConsumerParameters as Params # Read in the database of parameters
 my_dictionary = Params.init_idiosyncratic_shocks # Create a dictionary containing the default values of the parameters
 import numpy as np # Get the suite of tools for doing numerical computation in python
-from HARKutilities import plotFuncs # Get some tools developed for plotting HARK functions
 from ConsIndShockModel import IndShockConsumerType # Set up the tools for solving a consumer's problem
 
 # define a function that generates the plot

--- a/ConsumptionSaving/ConsRepAgentModel.py
+++ b/ConsumptionSaving/ConsRepAgentModel.py
@@ -333,7 +333,6 @@ if __name__ == '__main__':
     from time import clock
     from HARKutilities import plotFuncs
     import ConsumerParameters as Params
-    import matplotlib.pyplot as plt
 
     # Make a quick example dictionary
     RA_params = deepcopy(Params.init_idiosyncratic_shocks)

--- a/ConsumptionSaving/Demos/Fagereng_demo.py
+++ b/ConsumptionSaving/Demos/Fagereng_demo.py
@@ -41,7 +41,6 @@ sys.path.insert(0, os.path.abspath('../../cstwMPC'))
 
 import numpy as np
 from copy import deepcopy
-from time import clock
 
 from HARKutilities import approxUniform, getPercentiles
 from HARKparallel import multiThreadCommands

--- a/ConsumptionSaving/RepAgentModel.py
+++ b/ConsumptionSaving/RepAgentModel.py
@@ -333,7 +333,6 @@ if __name__ == '__main__':
     from time import clock
     from HARKutilities import plotFuncs
     import ConsumerParameters as Params
-    import matplotlib.pyplot as plt
 
     # Make a quick example dictionary
     RA_params = deepcopy(Params.init_idiosyncratic_shocks)

--- a/HARKinterpolation.py
+++ b/HARKinterpolation.py
@@ -7,9 +7,7 @@ convergence.  The interpolator classes currently in this module inherit their
 distance method from HARKobject.
 '''
 
-import warnings
 import numpy as np
-from scipy.interpolate import UnivariateSpline
 from HARKcore import HARKobject
 from copy import deepcopy
 

--- a/HARKutilities.py
+++ b/HARKutilities.py
@@ -6,7 +6,6 @@ derivatives), manipulation of discrete distributions, and basic plotting tools.
 
 from __future__ import division     # Import Python 3.x division function
 import functools
-import re                           # Regular expression, for string cleaning
 import warnings
 import numpy as np                  # Python's numeric library, abbreviated "np"
 try:
@@ -22,7 +21,6 @@ except ImportError:
 import scipy.stats as stats         # Python's statistics library
 from scipy.interpolate import interp1d
 from scipy.special import erf, erfc
-from scipy.stats import norm
 
 def _warning(message,category = UserWarning,filename = '',lineno = -1):
     '''

--- a/cAndCwithStickyE/StickyE_NO_MARKOV.py
+++ b/cAndCwithStickyE/StickyE_NO_MARKOV.py
@@ -16,7 +16,6 @@ sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('../ConsumptionSaving'))
 
 import numpy as np
-import csv
 from time import clock
 from copy import deepcopy
 from StickyEmodel import StickyEconsumerType, StickyErepAgent, StickyCobbDouglasEconomy


### PR DESCRIPTION
In support of finding dependencies and transitive dependencies that make packaging HARK more difficult, remove some of the import statements that bring in dependencies that are not used in the code, as detected by flake8:

```bash
git ls-files '*.py' | xargs flake8 --select=F401
```

In particular, some of the apparently-unused imports not removed are due to usages flake8 can't detect, such as the fact that the HARKutilities.warnings import has side effects, or the `exec()` use of `copy.copy`.

Issue #85 Add setup.py so module can be installed