### PR TITLE
Add MPC to simulation in ConsGenIncProcessModel

### DIFF
--- a/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
@@ -1166,10 +1166,13 @@ class GenIncProcessConsumerType(IndShockConsumerType):
         None
         '''
         cLvlNow = np.zeros(self.AgentCount) + np.nan
+        MPCnow = np.zeros(self.AgentCount) + np.nan
         for t in range(self.T_cycle):
             these = t == self.t_cycle
             cLvlNow[these] = self.solution[t].cFunc(self.mLvlNow[these],self.pLvlNow[these])
+            MPCnow[these]  = self.solution[t].cFunc.derivativeX(self.mLvlNow[these],self.pLvlNow[these])
         self.cLvlNow = cLvlNow
+        self.MPCnow  = MPCnow
 
 
     def getPostStates(self):


### PR DESCRIPTION
The MPC is calculated and stored as an attribute (MPCnow) in some models, but this was omitted in ConsGenIncProcessModel.  As it turns out, this functionality is necessary for an exercise/notebook that is being prepared for NBER SI.