### PR TITLE
Remove relative import

### DIFF
--- a/HARK/ConsumptionSaving/ConsAggShockModel.py
+++ b/HARK/ConsumptionSaving/ConsAggShockModel.py
@@ -1753,7 +1753,7 @@ class AggShocksDynamicRule(HARKobject):
 ###############################################################################
 
 def main():
-    from . import ConsumerParameters as Params
+    import ConsumerParameters as Params
     from time import clock
     from HARK.utilities import plotFuncs
     mystr = lambda number : "{:.4f}".format(number)

--- a/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
@@ -1276,7 +1276,7 @@ class PersistentShockConsumerType(GenIncProcessConsumerType):
 ###############################################################################
 
 def main():
-    from . import ConsumerParameters as Params
+    import ConsumerParameters as Params
     from HARK.utilities import plotFuncs
     from time import clock
     import matplotlib.pyplot as plt

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2410,7 +2410,7 @@ def constructAssetsGrid(parameters):
 ####################################################################################################
 
 def main():
-    from . import ConsumerParameters as Params
+    import ConsumerParameters as Params
     from HARK.utilities import plotFuncsDer, plotFuncs
     from time import clock
     mystr = lambda number : "{:.4f}".format(number)

--- a/HARK/ConsumptionSaving/ConsMarkovModel.py
+++ b/HARK/ConsumptionSaving/ConsMarkovModel.py
@@ -974,7 +974,7 @@ class MarkovConsumerType(IndShockConsumerType):
 ###############################################################################
 
 def main():
-    from . import ConsumerParameters as Params
+    import ConsumerParameters as Params
     from HARK.utilities import plotFuncs
     from time import clock
     from copy import copy

--- a/HARK/ConsumptionSaving/ConsMedModel.py
+++ b/HARK/ConsumptionSaving/ConsMedModel.py
@@ -1359,7 +1359,7 @@ def solveConsMedShock(solution_next,IncomeDstn,MedShkDstn,LivPrb,DiscFac,CRRA,CR
 ###############################################################################
 
 def main():
-    from . import ConsumerParameters as Params
+    import ConsumerParameters as Params
     from HARK.utilities import CRRAutility_inv
     from time import clock
     import matplotlib.pyplot as plt

--- a/HARK/ConsumptionSaving/ConsPrefShockModel.py
+++ b/HARK/ConsumptionSaving/ConsPrefShockModel.py
@@ -594,7 +594,7 @@ def solveConsKinkyPref(solution_next,IncomeDstn,PrefShkDstn,
 ###############################################################################
 
 def main():
-    from . import ConsumerParameters as Params
+    import ConsumerParameters as Params
     import matplotlib.pyplot as plt
     from HARK.utilities import plotFuncs
     from time import clock

--- a/HARK/ConsumptionSaving/ConsRepAgentModel.py
+++ b/HARK/ConsumptionSaving/ConsRepAgentModel.py
@@ -331,7 +331,7 @@ def main():
     from copy import deepcopy
     from time import clock
     from HARK.utilities import plotFuncs
-    from . import ConsumerParameters as Params
+    import ConsumerParameters as Params
 
     # Make a quick example dictionary
     RA_params = deepcopy(Params.init_idiosyncratic_shocks)

--- a/HARK/ConsumptionSaving/RepAgentModel.py
+++ b/HARK/ConsumptionSaving/RepAgentModel.py
@@ -331,7 +331,7 @@ def main():
     from copy import deepcopy
     from time import clock
     from HARK.utilities import plotFuncs
-    from . import ConsumerParameters as Params
+    import ConsumerParameters as Params
 
     # Make a quick example dictionary
     RA_params = deepcopy(Params.init_idiosyncratic_shocks)

--- a/HARK/ConsumptionSaving/TractableBufferStockModel.py
+++ b/HARK/ConsumptionSaving/TractableBufferStockModel.py
@@ -474,7 +474,7 @@ def main():
     # contained in the HARK folder.  Also import the ConsumptionSavingModel
     import numpy as np                   # numeric Python
     from HARK.utilities import plotFuncs  # basic plotting tools
-    from .ConsMarkovModel import MarkovConsumerType # An alternative, much longer way to solve the TBS model
+    from ConsMarkovModel import MarkovConsumerType # An alternative, much longer way to solve the TBS model
     from time import clock               # timing utility
 
     do_simulation = True


### PR DESCRIPTION
HARK uses the "from . import foo as bar" construction, but I don't see how the relative import adds any useful semantics as opposed to just doing "import foo as bar".  The relative import threw an error:

> Traceback (most recent call last):
>   File "ConsIndShockModel.py", line 2559, in <module>
>     main()
>   File "ConsIndShockModel.py", line 2413, in main
>     from . import ConsumerParameters as Params
> ValueError: Attempted relative import in non-package

This patch just does a normal absolute import using the module system so we avoid the relative import and avoid throwing that error.  I made this change for every relative import in main() in ConsumptionSaving.

Most of the files in that ConsumptionSaving directory use the relative import at the top level, though I don't understand why.  if we need it for some scenario, I don't see what it is.