### PR TITLE
Setup basic travis support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - 2.7
+  - 3.6
+cache: pip
+install:
+  - pip install -r requirements.txt
+script:
+  - pytest HARK/tests

--- a/HARK/tests/test_initial.py
+++ b/HARK/tests/test_initial.py
@@ -1,0 +1,64 @@
+"""
+This file implements unit tests to check HARK/utilities.py
+"""
+from __future__ import print_function, division
+from __future__ import absolute_import
+
+from builtins import str
+from builtins import zip
+from builtins import range
+from builtins import object
+
+import HARK.utilities
+
+# Bring in modules we need
+import unittest
+import numpy as np
+
+class testsForHARKutilities(unittest.TestCase):
+
+    def setUp(self):
+        self.c_vals    = np.linspace(.5,10.,20)
+        self.CRRA_vals = np.linspace(1.,10.,10)
+
+    def first_diff_approx(self,func,x,delta,*args):
+        """
+        Take the first (centered) difference approximation to the derivative of a function.
+
+        """
+        return (func(x+delta,*args) - func(x-delta,*args)) / (2. * delta)
+
+    def derivative_func_comparison(self,deriv,func):
+        """
+        This method computes the first difference approximation to the derivative of a function
+        "func" and the (supposedly) closed-form derivative of that function ("deriv") over a
+        grid.  It then checks that these two things are "close enough."
+        """
+
+        # Loop through different values of consumption
+        for c in self.c_vals:
+            # Loop through different values of risk aversion
+            for CRRA in self.CRRA_vals:
+
+                # Calculate the difference between the derivative of the function and the
+                # first difference approximation to that derivative.
+                diff = abs(deriv(c,CRRA) - self.first_diff_approx(func,c,.000001,CRRA))
+
+                # Make sure the derivative and its approximation are close
+                self.assertLess(diff,.01)
+
+    def test_CRRAutilityP(self):
+        # Test the first derivative of the utility function
+        self.derivative_func_comparison(HARK.utilities.CRRAutilityP,HARK.utilities.CRRAutility)
+
+    def test_CRRAutilityPP(self):
+        # Test the second derivative of the utility function
+        self.derivative_func_comparison(HARK.utilities.CRRAutilityPP,HARK.utilities.CRRAutilityP)
+
+    def test_CRRAutilityPPP(self):
+        # Test the third derivative of the utility function
+        self.derivative_func_comparison(HARK.utilities.CRRAutilityPPP,HARK.utilities.CRRAutilityPP)
+
+    def test_CRRAutilityPPPP(self):
+        # Test the fourth derivative of the utility function
+        self.derivative_func_comparison(HARK.utilities.CRRAutilityPPPP,HARK.utilities.CRRAutilityPPP)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpydoc
 future
 joblib
 dill
+scipy


### PR DESCRIPTION
Since I don't have the `econ-ark` keys, I need someone to log in to https://travis-ci.org/ and click the button to enable github integration for the travis-ci service.

I put in the simplest test module from `Testing` just to show how it works. If you want this, then I'd hope it could be merged with only these basic tests, and then I can add the rest later. I had problems running the some of the other test modules (kind of shows why we need this), but I'd rather use this infrastructure to add tests for some of the discrete choice functions that I'm using in the other PRs, and make PRs for those. Then I can come back to fix some of the problems with the other test modules.

I have never used travis for python projects, so it took a bit of experimenting, but a `tests` folder with an `__init__.py` file seemed to be simplest.

To add more `unittest` modules, you simply need to place them in `tests/test_,,,.py` files, and `pytest` (which is run by travis) will find them.

*edit*
Oh, and the python versions are somewhat arbitrary, we can add more (but 3.7 needs a hacky solution to work).

Travis is free for open source projects, and they give you buildbots that should more than suffice for a project with HARK's PR activity.

This will help avoid #175 in the future!