### PR TITLE
Update FashionVictim to work as HARK package

### DIFF
--- a/HARK/FashionVictim/FashionVictimModel.py
+++ b/HARK/FashionVictim/FashionVictimModel.py
@@ -15,7 +15,7 @@ from HARK.interpolation import LinearInterp
 from HARK.utilities import approxUniform, plotFuncs
 import numpy as np
 import scipy.stats as stats
-from . import FashionVictimParams as Params
+from HARK.FashionVictim import FashionVictimParams as Params
 from copy import copy
 
 class FashionSolution(Solution):


### PR DESCRIPTION
This is a tiny fix needed to bring FashionVictim up to date with the changes that happened when HARK became pip-installable.  No longer right to say "from . import" -- instead it need to be "from HARK.FashionVictim import".