### PR TITLE
Remove incorrect statement in updateIncomeProcess

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -1783,9 +1783,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
 
     def updateIncomeProcess(self):
         '''
-        Updates this agent's income process based on his own attributes.  The
-        function that generates the discrete income process can be swapped out
-        for a different process.
+        Updates this agent's income process based on his own attributes.
 
         Parameters
         ----------


### PR DESCRIPTION
@mnwhite this seems to be wrong, right? I don't see any `self.constructIncomeProcess`-ish statements, so it appears that the mean one log-normal equiprobably version is hard-coded. Correct?

I think we should remove the statement unless I missed something in the code, and if it's a *planned* feature, let's just open an issue.