### PR TITLE
Fix for nan_bool in Py2

### DIFF
--- a/HARK/interpolation.py
+++ b/HARK/interpolation.py
@@ -1642,7 +1642,7 @@ class LowerEnvelope(HARKinterpolator1D):
     '''
     distance_criteria = ['functions']
 
-    def __init__(self, *functions, nan_bool = True):
+    def __init__(self, nan_bool=True, *functions):
         '''
         Constructor to make a new lower envelope iterpolation.
 
@@ -1720,7 +1720,7 @@ class UpperEnvelope(HARKinterpolator1D):
     '''
     distance_criteria = ['functions']
 
-    def __init__(self,*functions, nan_bool=True):
+    def __init__(self, nan_bool=True, *functions):
         '''
         Constructor to make a new upper envelope iterpolation.
 
@@ -1798,7 +1798,7 @@ class LowerEnvelope2D(HARKinterpolator2D):
     '''
     distance_criteria = ['functions']
 
-    def __init__(self,*functions, nan_bool = True):
+    def __init__(self, nan_bool = True, *functions):
         '''
         Constructor to make a new lower envelope iterpolation.
 
@@ -1886,7 +1886,7 @@ class LowerEnvelope3D(HARKinterpolator3D):
     '''
     distance_criteria = ['functions']
 
-    def __init__(self,*functions, nan_bool = True):
+    def __init__(self, nan_bool = True, *functions):
         '''
         Constructor to make a new lower envelope iterpolation.
 


### PR DESCRIPTION
Py2 can't accept named inputs after an *args list, but Py3 can.  Recent PR with nan_bool functionality for UpperEnvelope (etc) worked in Py2 but not Py3.  Attempting fix.

Not ready to merge, issuing a PR in order to use Travis tests.