### PR TITLE
Undo nan_bool merge

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -893,7 +893,8 @@ class ConsIndShockSolverBasic(ConsIndShockSetup):
         cFuncNowUnc = interpolator(mNrm,cNrm)
 
         # Combine the constrained and unconstrained functions into the true consumption function
-        cFuncNow = LowerEnvelope(cFuncNowUnc, self.cFuncNowCnst, nan_bool = False)
+        cFuncNow = LowerEnvelope(cFuncNowUnc, self.cFuncNowCnst,
+                                 nan_bool = False)
 
         # Make the marginal value function and the marginal marginal value function
         vPfuncNow = MargValueFunc(cFuncNow,self.CRRA)

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -893,8 +893,7 @@ class ConsIndShockSolverBasic(ConsIndShockSetup):
         cFuncNowUnc = interpolator(mNrm,cNrm)
 
         # Combine the constrained and unconstrained functions into the true consumption function
-        cFuncNow = LowerEnvelope(cFuncNowUnc, self.cFuncNowCnst,
-                                 nan_bool = False)
+        cFuncNow = LowerEnvelope(cFuncNowUnc,self.cFuncNowCnst)
 
         # Make the marginal value function and the marginal marginal value function
         vPfuncNow = MargValueFunc(cFuncNow,self.CRRA)
@@ -1215,7 +1214,7 @@ def solveConsIndShock(solution_next,IncomeDstn,LivPrb,DiscFac,CRRA,Rfree,PermGro
         included in the reported solution.
     CubicBool: boolean
         Indicator for whether the solver should use cubic or linear interpolation.
-    
+
     Returns
     -------
     solution_now : ConsumerSolution


### PR DESCRIPTION
Tim Munday's nan_bool feature on LowerEnvelope (etc), which had been merged into master by me, worked on Py3 but not Py2.  Trying to fix by rearranging order of inputs failed, so this PR reverts that PR.

We still do want nan_bool, but will need to change the syntax of LowerEnvelope (etc) *and everywhere it's implemented* from 

`def __init__(self,*functions):`

to

`def __init__(self,functions):`

This only requires throwing brackets around all of the argument lists where we make a LowerEnvelope (etc), but we need to be thorough.  Should also discuss how to handle the fact that we're changing syntax of a long-standing function class, so *other people*'s code will break next time they update HARK, if they were using this.