### PR TITLE
Changed hardcoded updateAFunc parameters into proper parameters

### DIFF
--- a/HARK/ConsumptionSaving/ConsAggShockModel.py
+++ b/HARK/ConsumptionSaving/ConsAggShockModel.py
@@ -901,9 +901,20 @@ class CobbDouglasEconomy(Market):
                             tolerance=tolerance,
                             act_T=act_T)
         self.assignParameters(**kwds)
-        self.max_loops = 20
         self.update()
-
+        
+        # Use previously hardcoded values for AFunc updating if not passed
+        # as part of initialization dictionary.  This is to prevent a last
+        # minute update to HARK before a release from having a breaking change.
+        if not hasattr(self,'DampingFac'):
+            self.DampingFac = 0.5
+        if not hasattr(self,'max_loops'):
+            self.max_loops = 20
+        if not hasattr(self,'T_discard'):
+            self.T_discard = 200
+        if not hasattr(self,'verbose'):
+            self.verbose = True
+        
 
     def millRule(self,aLvlNow,pLvlNow):
         '''
@@ -998,11 +1009,11 @@ class CobbDouglasEconomy(Market):
 
         Parameters
         ----------
-        none
+        None
 
         Returns
         -------
-        none
+        None
         '''
         self.Shk_idx = 0
         Market.reset(self)
@@ -1015,11 +1026,11 @@ class CobbDouglasEconomy(Market):
 
         Parameters
         ----------
-        none
+        None
 
         Returns
         -------
-        none
+        None
         '''
         sim_periods = self.act_T
         Events      = np.arange(self.AggShkDstn[0].size) # just a list of integers
@@ -1085,18 +1096,18 @@ class CobbDouglasEconomy(Market):
         Parameters
         ----------
         MaggNow : [float]
-            List of the history of the simulated  aggregate market resources for an economy.
+            List of the history of the simulated aggregate market resources for an economy.
         AaggNow : [float]
-            List of the history of the simulated  aggregate savings for an economy.
+            List of the history of the simulated aggregate savings for an economy.
 
         Returns
         -------
         (unnamed) : CapDynamicRule
             Object containing a new savings rule
         '''
-        verbose = True
-        discard_periods = 200 # Throw out the first T periods to allow the simulation to approach the SS
-        update_weight = 0.80  # Proportional weight to put on new function vs old function parameters
+        verbose = self.verbose
+        discard_periods = self.T_discard # Throw out the first T periods to allow the simulation to approach the SS
+        update_weight = 1. - self.DampingFac  # Proportional weight to put on new function vs old function parameters
         total_periods = len(MaggNow)
 
         # Regress the log savings against log market resources

--- a/HARK/ConsumptionSaving/ConsAggShockModel.py
+++ b/HARK/ConsumptionSaving/ConsAggShockModel.py
@@ -1587,9 +1587,9 @@ class CobbDouglasMarkovEconomy(CobbDouglasEconomy):
         (unnamed) : CapDynamicRule
             Object containing new saving rules for each Markov state.
         '''
-        verbose = True
-        discard_periods = 200 # Throw out the first T periods to allow the simulation to approach the SS
-        update_weight = 0.8   # Proportional weight to put on new function vs old function parameters
+        verbose = self.verbose
+        discard_periods = self.T_discard # Throw out the first T periods to allow the simulation to approach the SS
+        update_weight = 1. - self.DampingFac  # Proportional weight to put on new function vs old function parameters
         total_periods = len(MaggNow)
 
         # Trim the histories of M_t and A_t and convert them to logs
@@ -1773,7 +1773,7 @@ def main():
     solve_agg_shocks_market = True # Solve for the equilibrium aggregate saving rule in a CobbDouglasEconomy
 
     solve_markov_micro = False # Solve an AggShockMarkovConsumerType's microeconomic problem
-    solve_markov_market = False # Solve for the equilibrium aggregate saving rule in a CobbDouglasMarkovEconomy
+    solve_markov_market = True # Solve for the equilibrium aggregate saving rule in a CobbDouglasMarkovEconomy
     solve_krusell_smith = True # Solve a simple Krusell-Smith-style two state, two shock model
     solve_poly_state = False   # Solve a CobbDouglasEconomy with many states, potentially utilizing the "state jumper"
 
@@ -1838,6 +1838,7 @@ def main():
 
         # Make a Cobb-Douglas economy for the agents
         MrkvEconomyExample = CobbDouglasMarkovEconomy(agents = [AggShockMrkvExample],**Params.init_mrkv_cobb_douglas)
+        MrkvEconomyExample.DampingFac = 0.2 # Turn down damping
         MrkvEconomyExample.makeAggShkHist() # Simulate a history of aggregate shocks
         AggShockMrkvExample.getEconomyData(MrkvEconomyExample) # Have the consumers inherit relevant objects from the economy
 
@@ -1867,7 +1868,7 @@ def main():
         t_end = clock()
         print('Solving the "macroeconomic" aggregate shocks model took ' + str(t_end - t_start) + ' seconds.')
 
-        print('Aggregate savings as a function of aggregate market resources (for each macro state):')
+        print('Consumption function at each aggregate market resources-to-labor ratio gridpoint (for each macro state):')
         m_grid = np.linspace(0,10,200)
         AggShockMrkvExample.unpackcFunc()
         for i in range(2):

--- a/HARK/ConsumptionSaving/ConsumerParameters.py
+++ b/HARK/ConsumptionSaving/ConsumerParameters.py
@@ -179,6 +179,10 @@ DiscFacPF = DiscFac           # Discount factor of perfect foresight calibration
 CRRAPF = CRRA                 # Coefficient of relative risk aversion of perfect foresight calibration
 intercept_prev = 0.0          # Intercept of aggregate savings function
 slope_prev = 1.0              # Slope of aggregate savings function
+verbose_cobb_douglas = True   # Whether to print solution progress to screen while solving
+T_discard = 200               # Number of simulated "burn in" periods to discard when updating AFunc
+DampingFac = 0.5              # Damping factor when updating AFunc; puts DampingFac weight on old params, rest on new
+max_loops = 20                # Maximum number of AFunc updating loops to allow
 
 # Make a dictionary to specify an aggregate shocks consumer
 init_agg_shocks = copy(init_idiosyncratic_shocks)
@@ -205,7 +209,11 @@ init_cobb_douglas = {'PermShkAggCount': PermShkAggCount,
                      'AggregateL':1.0,
                      'act_T':1200,
                      'intercept_prev': intercept_prev,
-                     'slope_prev': slope_prev
+                     'slope_prev': slope_prev,
+                     'verbose': verbose_cobb_douglas,
+                     'T_discard': T_discard,
+                     'DampingFac': DampingFac,
+                     'max_loops': max_loops
                      }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Four parameters that govern how CobbDouglasEconomy.updateAFunc works
were defined locally, within the method, but are now attributes to be
assigned at init (or at least before the user tries to solve):

- update_weight --> DampingFac, now defined complementarily
- verbose --> verbose
- discard_periods --> T_discard
- max_loops --> max_loops

To prevent this from being a breaking change, init method writes old
hardcoded values if omitted from passed inputs.  This will be improved
with a warning later.

Untested, as it turns out Anaconda3 is incorrectly installed on this
computer.