### PR TITLE
Add Flake8 to requirements, setup, and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ install:
   - pip install -r requirements.txt
 script:
   - pytest HARK/tests
+  # - flake8 HARK

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ future
 joblib
 dill
 scipy
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,8 @@ license_file = LICENSE
 # bdist_wheel from trying to make a universal wheel. For more see:
 # https://packaging.python.org/tutorials/distributing-packages/#wheels
 
+[flake8]
+exclude = .git
+max-line-length = 119
+
 universal=1


### PR DESCRIPTION
This PR adds Flake8 tests to Travis, and also install Flake8 with the requirements so people can lint the codebase locally.  I've also added it to the config file and made an initial adjustment of setting our max line length to 120.