### PR TITLE
Moved checkConditions out of init

### DIFF
--- a/HARK/ConsumptionSaving/ConsAggShockModel.py
+++ b/HARK/ConsumptionSaving/ConsAggShockModel.py
@@ -105,6 +105,9 @@ class AggShockConsumerType(IndShockConsumerType):
         self.initializeSim()
         self.aLvlNow = self.kInit*np.ones(self.AgentCount)  # Start simulation near SS
         self.aNrmNow = self.aLvlNow/self.pLvlNow
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def updateSolutionTerminal(self):
         '''

--- a/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
@@ -985,6 +985,9 @@ class GenIncProcessConsumerType(IndShockConsumerType):
         # Initialize a basic ConsumerType
         IndShockConsumerType.__init__(self, cycles=cycles, time_flow=time_flow, **kwds)
         self.solveOnePeriod = solveConsGenIncProcess  # idiosyncratic shocks solver with explicit persistent income
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def update(self):
         '''

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -1496,6 +1496,10 @@ class PerfForesightConsumerType(AgentType):
         self.verbose        = verbose
         self.quiet          = quiet
         self.solveOnePeriod = solvePerfForesight # solver for perfect foresight model
+        
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def updateSolutionTerminal(self):
         '''
@@ -1539,7 +1543,6 @@ class PerfForesightConsumerType(AgentType):
         self.PlvlAggNow = 1.0
         self.PermShkAggNow = self.PermGroFacAgg # This never changes during simulation
         AgentType.initializeSim(self)
-
 
 
     def simBirth(self,which_agents):
@@ -1748,6 +1751,7 @@ class PerfForesightConsumerType(AgentType):
 
         return violated
 
+
 class IndShockConsumerType(PerfForesightConsumerType):
     '''
     A consumer type with idiosyncratic shocks to permanent and transitory income.
@@ -1784,9 +1788,6 @@ class IndShockConsumerType(PerfForesightConsumerType):
         self.solveOnePeriod = solveConsIndShock # idiosyncratic shocks solver
         self.update() # Make assets grid, income process, terminal solution
 
-        if not self.quiet:
-            self.checkConditions(verbose=self.verbose,
-                                 public_call=False)
 
     def updateIncomeProcess(self):
         '''
@@ -2010,8 +2011,9 @@ class IndShockConsumerType(PerfForesightConsumerType):
         self.eulerErrorFunc = eulerErrorFunc
 
     def preSolve(self):
-        PerfForesightConsumerType.preSolve(self)
         self.updateSolutionTerminal()
+        if not self.quiet:
+            self.checkConditions(verbose=self.verbose,public_call=False)
 
     def checkConditions(self,verbose=False,public_call=True):
         '''
@@ -2079,6 +2081,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
         if verbose and violated:
             print('\n[!] For more information on the conditions, see Table 3 in "Theoretical Foundations of Buffer Stock Saving" at http://econ.jhu.edu/people/ccarroll/papers/BufferStockTheory/')
 
+
 class KinkedRconsumerType(IndShockConsumerType):
     '''
     A consumer type that faces idiosyncratic shocks to income and has a different
@@ -2113,6 +2116,9 @@ class KinkedRconsumerType(IndShockConsumerType):
         # Add consumer-type specific objects, copying to create independent versions
         self.solveOnePeriod = solveConsKinkedR # kinked R solver
         self.update() # Make assets grid, income process, terminal solution
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def calcBoundingValues(self):
         '''

--- a/HARK/ConsumptionSaving/ConsMarkovModel.py
+++ b/HARK/ConsumptionSaving/ConsMarkovModel.py
@@ -723,9 +723,8 @@ class MarkovConsumerType(IndShockConsumerType):
 
     def preSolve(self):
         """
-        Do preSolve stuff inherited from IndShockConsumerType, then check to make sure that the
-        inputs that are specific to MarkovConsumerType are of the right shape (if arrays) or length
-        (if lists).
+        Check to make sure that the inputs that are specific to MarkovConsumerType
+        are of the right shape (if arrays) or length (if lists).
 
         Parameters
         ----------
@@ -735,7 +734,7 @@ class MarkovConsumerType(IndShockConsumerType):
         -------
         None
         """
-        IndShockConsumerType.preSolve(self)
+        self.updateSolutionTerminal()
         self.checkMarkovInputs()
 
     def updateSolutionTerminal(self):

--- a/HARK/ConsumptionSaving/ConsMedModel.py
+++ b/HARK/ConsumptionSaving/ConsMedModel.py
@@ -531,6 +531,9 @@ class MedShockConsumerType(PersistentShockConsumerType):
         self.solveOnePeriod = solveConsMedShock # Choose correct solver
         self.addToTimeInv('CRRAmed')
         self.addToTimeVary('MedPrice')
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def update(self):
         '''

--- a/HARK/ConsumptionSaving/ConsPrefShockModel.py
+++ b/HARK/ConsumptionSaving/ConsPrefShockModel.py
@@ -43,6 +43,9 @@ class PrefShockConsumerType(IndShockConsumerType):
         '''
         IndShockConsumerType.__init__(self,cycles=cycles,time_flow=time_flow,**kwds)
         self.solveOnePeriod = solveConsPrefShock # Choose correct solver
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def update(self):
         '''
@@ -207,6 +210,9 @@ class KinkyPrefConsumerType(PrefShockConsumerType,KinkedRconsumerType):
         self.solveOnePeriod = solveConsKinkyPref # Choose correct solver
         self.addToTimeInv('Rboro','Rsave')
         self.delFromTimeInv('Rfree')
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def getRfree(self): # Specify which getRfree to use
         return KinkedRconsumerType.getRfree(self)

--- a/HARK/ConsumptionSaving/ConsRepAgentModel.py
+++ b/HARK/ConsumptionSaving/ConsRepAgentModel.py
@@ -209,6 +209,9 @@ class RepAgentConsumerType(IndShockConsumerType):
         self.AgentCount = 1 # Hardcoded, because this is rep agent
         self.solveOnePeriod = solveConsRepAgent
         self.delFromTimeInv('Rfree','BoroCnstArt','vFuncBool','CubicBool')
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def getStates(self):
         '''
@@ -257,6 +260,9 @@ class RepAgentMarkovConsumerType(RepAgentConsumerType):
         '''
         RepAgentConsumerType.__init__(self,time_flow=time_flow,**kwds)
         self.solveOnePeriod = solveConsRepAgentMarkov
+        
+    def preSolve(self):
+        self.updateSolutionTerminal()
 
     def updateSolutionTerminal(self):
         '''


### PR DESCRIPTION
IndShockConsumerType.__init__ was calling its checkConditions method, but this caused many subclasses to fail, as their checkConditions method either throws a notImplementedError or runs into an attribute error.

CDC wants checkConditions called automatically, so this is now done in preSolve().  All subclasses have had a trivial preSolve method added, which only calls updateSolutionTerminal.