### PR TITLE
Fix typo in Market.__init__

### DIFF
--- a/HARK/core.py
+++ b/HARK/core.py
@@ -885,7 +885,7 @@ class Market(HARKobject):
     dynamic general equilibrium models to solve the "macroeconomic" model as a
     layer on top of the "microeconomic" models of one or more AgentTypes.
     '''
-    def __init__(self, agents=[], sow_vars=[], reap_vars=[], const_vars=[], rack_vars=[], dyn_vars=[],
+    def __init__(self, agents=[], sow_vars=[], reap_vars=[], const_vars=[], track_vars=[], dyn_vars=[],
                  millRule=None, calcDynamics=None, act_T=1000, tolerance=0.000001):
         '''
         Make a new instance of the Market class.


### PR DESCRIPTION
Delinting at PyCon created a typo in the argument list for Market, now fixed.  This addresses the same issue as just-closed PR from CDC #285 