### PR TITLE
Throw an Exception if model has not been solved prior to simulate'ing

### DIFF
--- a/HARK/core.py
+++ b/HARK/core.py
@@ -481,6 +481,9 @@ class AgentType(HARKobject):
         -------
         None
         '''
+        if not hasattr(self, 'solution'):
+            raise Exception('Model instance does not have a solution stored. To simulate, it is necessary to run the `solve()` method of the class first.')
+
         self.getMortality()  # Replace some agents with "newborns"
         if self.read_shocks:  # If shock histories have been pre-specified, use those
             self.readShocks()
@@ -1323,6 +1326,7 @@ def copy_module_to_local(full_module_name):
         'y' to accept the default home directory: """+home_directory_with_module+"""
         'n' to specify your own pathname\n\n""")
 
+
     if target_path == 'n' or target_path == 'N':
         target_path = input("""Please enter the full pathname to your target directory location: """)
 
@@ -1342,6 +1346,12 @@ def copy_module_to_local(full_module_name):
     else:
         # Assume "quit"
         return
+
+    if target_path != 'q' and target_path != 'Q' or target_path == '':
+        # Run the copy command:
+        copy_module(target_path, my_directory_full_path, my_module)
+
+    return
 
     if target_path != 'q' and target_path != 'Q' or target_path == '':
         # Run the copy command:

--- a/HARK/tests/test_simulate.py
+++ b/HARK/tests/test_simulate.py
@@ -19,4 +19,5 @@ class testsForIndShk(unittest.TestCase):
         model.t_cycle = 0
         model.t_age=18
         # But forget to solve, and go straight to simulate
-        self.assertRaises(Exception, model.simulate())
+        with self.assertRaises(Exception):
+            model.simulate()

--- a/HARK/tests/test_simulate.py
+++ b/HARK/tests/test_simulate.py
@@ -1,0 +1,22 @@
+"""
+This file implements unit tests for the simulate method.
+"""
+
+# Bring in modules we need
+import unittest
+
+from HARK.ConsumptionSaving.ConsIndShockModel import IndShockConsumerType
+import HARK.ConsumptionSaving.ConsumerParameters as param
+
+class testsForIndShk(unittest.TestCase):
+    def setUp(self):
+        pars = param.init_lifecycle
+        self.model = IndShockConsumerType(**pars)
+    def test_no_solve(self):
+        model = self.model
+        # Correctly assign time variables
+        model.T_sim = 4
+        model.t_cycle = 0
+        model.t_age=18
+        # But forget to solve, and go straight to simulate
+        self.assertRaises(Exception, model.simulate())


### PR DESCRIPTION
So, I'm just PRing some minor things I'm finding on my way to matching a portfolio share. I've actually thought about this before (last fall!) but you quickly forget these things/learn to live with them.

Essentially, before this PR, if you tried to `simulate()`, but you hadn't `solve()`ed, you would just get a message stating that

```
AttributeError: 'IndShockConsumerType' object has no attribute 'solution'.
```

I'm not sure that all new users, and maybe new python users, would immediately know why this is. We probably know what went wrong though! They didn't `solve`.

Added a simple test to verify that this is actually thrown by initializing an `IndShockConsumerType`, setting it up, running simulate, but without having solved it.