### PR TITLE
Updatepresolve

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -1496,8 +1496,8 @@ class PerfForesightConsumerType(AgentType):
         self.verbose        = verbose
         self.quiet          = quiet
         self.solveOnePeriod = solvePerfForesight # solver for perfect foresight model
-        
-        
+
+
     def preSolve(self):
         self.updateSolutionTerminal()
 
@@ -1711,10 +1711,10 @@ class PerfForesightConsumerType(AgentType):
         None
         '''
         if self.cycles!=0 or self.T_cycle > 1:
-            if verbose == True: 
+            if verbose == True:
                 print('This method only checks for the conditions for infinite horizon models with a 1 period cycle')
             return
-        
+
         violated = False
 
         #Evaluate and report on the return impatience condition
@@ -2011,6 +2011,9 @@ class IndShockConsumerType(PerfForesightConsumerType):
         self.eulerErrorFunc = eulerErrorFunc
 
     def preSolve(self):
+        # Update all income process variables to match any attributes that might
+        # have been changed since `__init__` or `solve()` was last called.
+        self.updateIncomeProcess()
         self.updateSolutionTerminal()
         if not self.quiet:
             self.checkConditions(verbose=self.verbose,public_call=False)
@@ -2022,7 +2025,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
         impatience condition (WRIC), finite human wealth condition (FHWC) and finite value of
         autarky condition (FVAC). These are the conditions that are sufficient for nondegenerate
         solutions under infinite horizon with a 1 period cycle. Depending on the model at hand, a
-        different combination of these conditions must be satisfied. (For an exposition of the 
+        different combination of these conditions must be satisfied. (For an exposition of the
         conditions, see http://econ.jhu.edu/people/ccarroll/papers/BufferStockTheory/)
 
         Parameters
@@ -2116,7 +2119,7 @@ class KinkedRconsumerType(IndShockConsumerType):
         # Add consumer-type specific objects, copying to create independent versions
         self.solveOnePeriod = solveConsKinkedR # kinked R solver
         self.update() # Make assets grid, income process, terminal solution
-        
+
     def preSolve(self):
         self.updateSolutionTerminal()
 


### PR DESCRIPTION
Fixes #222 at the expense of a few more calculations each time `solve` is called. Advanced users can easily create a `MyIndShkType` and overwrite `preSolve` with a new 3-line method that doesn't update between `solve()` calls. The cost is probably negligible anyway, compared to solving the model and any post-processing you might do after solving a model. 