### PR TITLE
Fix datafile packaging issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,9 +176,8 @@ setup(
     #
     # If using Python 2.6 or earlier, then these have to be included in
     # MANIFEST.in as well.
-    include_package_data=True,
     package_data={  # Optional
-        'HARK.SolvingMicroDSOPs': ['SCFdata.csv'],
+        'HARK.SolvingMicroDSOPs.Calibration': ['SCFdata.csv'],
         'HARK.cstwMPC': [
              'EducMortAdj.txt',
              'SCFwealthDataReduced.txt',


### PR DESCRIPTION
Fixes issue #279.  Removes line `include_package_data=True,` in `setup.py`, an alternative method for including data files which wasn't working due to the relevant lines being commented out in `manifest.in and which was conflicting with the more precise specification of which files we wanted.  Also fixes the path for the `SCFdata.csv` file, which pointed to the wrong directory.