### PR TITLE
Undo June 20 commit to preSolve AgentType because it breaks things

### DIFF
--- a/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
@@ -987,7 +987,7 @@ class GenIncProcessConsumerType(IndShockConsumerType):
         self.solveOnePeriod = solveConsGenIncProcess  # idiosyncratic shocks solver with explicit persistent income
 
     def preSolve(self):
-        AgentType.preSolve()
+#        AgentType.preSolve()
         self.updateSolutionTerminal()
 
     def update(self):

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2017,10 +2017,10 @@ class IndShockConsumerType(PerfForesightConsumerType):
         self.eulerErrorFunc = eulerErrorFunc
 
     def preSolve(self):
-        AgentType.preSolve(self)
+#        AgentType.preSolve(self)
         # Update all income process variables to match any attributes that might
         # have been changed since `__init__` or `solve()` was last called.
-        self.updateIncomeProcess()
+#        self.updateIncomeProcess()
         self.updateSolutionTerminal()
         if not self.quiet:
             self.checkConditions(verbose=self.verbose,public_call=False)
@@ -2128,7 +2128,7 @@ class KinkedRconsumerType(IndShockConsumerType):
         self.update() # Make assets grid, income process, terminal solution
 
     def preSolve(self):
-        AgentType.preSolve(self)
+#        AgentType.preSolve(self)
         self.updateSolutionTerminal()
 
     def calcBoundingValues(self):


### PR DESCRIPTION
@pkofod's commit on June 20 broke the KrusellSmith notebook among others -- this PR removes the lines that caused the problems (and also the functionality that they were intended to accomplish).  We need to revisit.
