### PR TITLE
Fix AdjustPrb for discrete portfolio choice.

### DIFF
--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -226,8 +226,6 @@ def _calcwFunc(AdjustPrb, AdjustCount, ShareNowCount, vFunc_adj, CRRA):
     integrand : function (lambda)
         Can be used to evaluate the integrand and the sent to a quadrature procedure.
     '''
-    if AdjustPrb < 1:
-        raise Exception('The code allowing probabilities of adjustment less than 1 is not working yet; release notes will indicate when we have a release where it work')
 
     # AdjustCount could in principle just be inferred from AdjustPrb instead of
     # cartying it arround FIXME / TODO
@@ -244,9 +242,6 @@ def _calcwFunc(AdjustPrb, AdjustCount, ShareNowCount, vFunc_adj, CRRA):
             evVals = AdjustPrb*vFunc_adj[0][ShareIndex](evalgrid) + (1-AdjustPrb)*vFunc_adj[1][ShareIndex](evalgrid)
             with np.errstate(divide='ignore', over='ignore', under='ignore', invalid='ignore'):
                 evValsNvrs = utility_inv(evVals,gam=CRRA)
-            evVals = np.insert(evVals, 0, 0.0)
-            evValsNvrs = np.insert(evVals, 0, 0.0)
-
             wFunc.append(ValueFunc(LinearInterp(evVals, evValsNvrs), CRRA))
 
     return wFunc
@@ -290,23 +285,23 @@ class PortfolioSolution(Solution):
                        vPfunc=None, RiskyShareFunc=None, vPPfunc=None,
                        mNrmMin=None, hNrm=None, MPCmin=None, MPCmax=None):
         """We implement three different ways to allow portfolio choice.
-           The agent can choose 
+           The agent can choose
               * any portfolio share ('continuous choice')
               * only a specified set of portfolio shares ('discrete choice')
                 * With probability 1 (agent always gets to choose)
                 * With probability 0 < p < 1 (stochastic chance to choose)
-        
-           We allow two choices for the description of the 
+
+           We allow two choices for the description of the
            distribution of the stochastic variable:
            1. A generic discrete probability distribution
               * Nodes and their probabilities are specified
            2. A true lognormal distribution
               * The mean return and the standard deviation are specified
-        
+
            In the discrete portfolio shares case, the user also must
            input a function that *draws* from the distribution in drawRiskyFunc
 
-           Other assumptions: 
+           Other assumptions:
               * distributions are time constant
               * probability of being allowed to reoptimize is time constant
                  * If p < 1, you must specify the PortfolioSet discretely


### PR DESCRIPTION
Fix #389 

So there were some leftover lines from a different way of constructing the re-curving value function interpolation.

A thing I noticed while trying this out to be sure it worked. If you set the probability to 0.5 and look at the share of periods where the agents can adjust, it'll be closer to 0.6 than 0.5. It could maybe be interesting to ask students to calculate the empirical share, and comment. (The answer is that when a new agent is replacing an old one whose lifecycle ended or who died, a new agent will always get the choice of their initial portfolio which implies a slightly higher "can adjust" ratio than 0.5).