### PR TITLE
fixes to requirements.txt to fix sphinx dependency errors. Fixes #406

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 matplotlib
-Sphinx
+sphinx==1.6.7
 numpydoc
 future
 joblib
@@ -12,3 +12,4 @@ funcsigs
 jupyter
 sphinx-rtd-theme
 nbsphinx
+recommonmark


### PR DESCRIPTION
Addresses #406 

- fixes `sphinx` version to one compatible with extension `numpydoc`
- installs `recommonmark` dependency