### PR TITLE
Robustify conda installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The Econ-ARK project uses an [open governance model](./GOVERNANCE.md) and is fis
 
 Install from [Anaconda Cloud](https://docs.anaconda.com/anaconda/install/) by running:
 
-`conda install econ-ark`
+`conda install -c conda-forge econ-ark`
 
 Install from [PyPi](https://pypi.org/) by running:
 


### PR DESCRIPTION
`conda install econ-ark` only works if the user has conda-forge as the default conda channel.  Replaced it with `conda install -c conda-forge econ-ark` which will work generically.