### PR TITLE
removing Model directories from the API documentation

### DIFF
--- a/Documentation/api.rst
+++ b/Documentation/api.rst
@@ -4,41 +4,7 @@ API Documentation
 .. autosummary::
    :toctree: generated
 
-   HARK.BayerLuetticke.Assets.One.FluctuationsOneAssetIOUs
-   HARK.BayerLuetticke.Assets.One.FluctuationsOneAssetIOUsBond
-   HARK.BayerLuetticke.Assets.One.SharedFunc
-   HARK.BayerLuetticke.Assets.One.SharedFunc2
-   HARK.BayerLuetticke.Assets.One.SteadyStateOneAssetIOUs
-   HARK.BayerLuetticke.Assets.One.SteadyStateOneAssetIOUsBond
-   HARK.BayerLuetticke.Assets.One.defineSSParameters
-   HARK.BayerLuetticke.Assets.One.defineSSParametersIOUsBond
-   HARK.BayerLuetticke.Assets.Two.FluctuationsTwoAsset
-   HARK.BayerLuetticke.Assets.Two.SharedFunc3
-   HARK.BayerLuetticke.Assets.Two.SteadyStateTwoAsset
-   HARK.BayerLuetticke.Assets.Two.defineSSParametersTwoAsset
-   HARK.BayerLuetticke.BayerLuetticke_wrapper
-   HARK.BayerLuetticke.ConsIndShockModel_extension
-   HARK.ConsumptionSaving.ConsAggShockModel
-   HARK.ConsumptionSaving.ConsGenIncProcessModel
-   HARK.ConsumptionSaving.ConsIndShockModel
-   HARK.ConsumptionSaving.ConsMarkovModel
-   HARK.ConsumptionSaving.ConsMedModel
-   HARK.ConsumptionSaving.ConsPrefShockModel
-   HARK.ConsumptionSaving.ConsRepAgentModel
-   HARK.ConsumptionSaving.ConsumerParameters
-   HARK.ConsumptionSaving.RepAgentModel
-   HARK.ConsumptionSaving.TractableBufferStockModel
-   HARK.FashionVictim.FashionVictimModel
-   HARK.FashionVictim.FashionVictimParams
-   HARK.SolvingMicroDSOPs.Calibration.EstimationParameters
-   HARK.SolvingMicroDSOPs.Calibration.SetupSCFdata
-   HARK.SolvingMicroDSOPs.Code.StructEstimation
-   HARK.SolvingMicroDSOPs.do_all
-   HARK.cAndCwithStickyE.StickyEmodel
-   HARK.cAndCwithStickyE.StickyEparams
-   HARK.cAndCwithStickyE.StickyEtools
    HARK.core
-   HARK.cstwMPC.cstwMPC
    HARK.dcegm
    HARK.estimation
    HARK.interpolation


### PR DESCRIPTION
The Python API readthedocs have too many entries for the specific models implemented in HARK (such as BayerLuetticke).

This PR removes all of those entries from the API documentation.

In the project meeting, we discussed remove everything below two layers in the module hierarchy (i.e., only entries of the form `HARK.*`). But since `HARK.BayerLuetticke` is a directory, not a module, the corresponding "API Doc" for this entry was empty and so is nonsensical.

The current implementation cleans up the ReadTheDocs to make them more usable.
It punts on the question of how to document the Models.