### PR TITLE
fix nbsphinx version to 0.4.3 to get compatibility with Sphinx v.1.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ jupyter
 funcsigs
 jupyter
 sphinx-rtd-theme
-nbsphinx
+nbsphinx==0.4.3
 recommonmark


### PR DESCRIPTION
The most recent `nbsphinx` release 0.5.0 is incompatible with Sphinx v1.6.7 and is breaking our ReadTheDocs build.

https://github.com/econ-ark/HARK/issues/409#issuecomment-558672732

This PR fixes `nbsphinx` to the previous version to try to get the build going again.