### PR TITLE
Tiny fix to getPercentiles

### DIFF
--- a/HARK/utilities.py
+++ b/HARK/utilities.py
@@ -1025,6 +1025,9 @@ def getPercentiles(data,weights=None,percentiles=[0.5],presorted=False):
     pctl_out : numpy.array
         The requested percentiles of the data.
     '''
+    if data.size < 2:
+        return np.zeros(np.array(percentiles).shape) + np.nan
+    
     if weights is None: # Set equiprobable weights if none were passed
         weights = np.ones(data.size)/float(data.size)
 


### PR DESCRIPTION
Added two lines to utilities.getPercentiles to correctly handle case when data has size 0 or 1: return NaN vector of same size as requested percentiles of data.  That is, there is no such thing as "percentiles" of an empty dataset or a singleton.  This can come up when simulated or empirical moments are calculated, but no observations qualify.