### PR TITLE
use github actions for testing MacOS, Windows and Ubuntu

### DIFF
--- a/.github/workflows/hark.yml
+++ b/.github/workflows/hark.yml
@@ -1,0 +1,35 @@
+name: HARK build on MacOS, Ubuntu and Windows
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+#     - name: Lint with flake8
+#       run: |
+#         pip install flake8
+#         # stop the build if there are Python syntax errors or undefined names
+#         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest


### PR DESCRIPTION
Github introduced Actions which can be used like Travis/Azure for testing code, I have added support for py 3.6 and 3.7 in MacOS, Windows and Ubuntu. [This is much faster than current Travis setup]

This will look like https://github.com/MridulS/HARK/runs/392930709 