### PR TITLE
Remove numpydoc dependency

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -39,7 +39,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
     'sphinx.ext.autosummary',
-    'numpydoc',
+    'sphinx.ext.napoleon',
     'nbsphinx',
     'recommonmark'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 matplotlib
 sphinx==1.6.7
-numpydoc
 future
 joblib
 dill

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,6 @@ setup(
             'future',  # Optional
             'Sphinx<=1.6.7',
             'nbsphinx',
-            'numpydoc',
             'recommonmark'
     ]},
 


### PR DESCRIPTION
Addresses #473

`numpydoc` is not a necessary dependency; its functionality is now part of `sphinx.ext.napoleon`