### PR TITLE
Fix typo in parallel.py

### DIFF
--- a/HARK/parallel.py
+++ b/HARK/parallel.py
@@ -378,7 +378,7 @@ def saveNelderMeadData(name, simplex, fvals, iters, evals):
     N = simplex.shape[0] # Number of points in simplex
     K = simplex.shape[1] # Total number of parameters
     
-    with open(name + '.txt','wb') as f:
+    with open(name + '.txt','w') as f:
         my_writer = csv.writer(f, delimiter=',')
         my_writer.writerow(simplex.shape)
         my_writer.writerow([iters, evals])
@@ -409,7 +409,7 @@ def loadNelderMeadData(name):
         The cumulative number of function evaluations in the search process.
     """
     # Open the Nelder-Mead progress file
-    with open(name + '.txt','rb') as f:
+    with open(name + '.txt','r') as f:
         my_reader = csv.reader(f, delimiter=',')
 
         # Get the shape of the simplex and initialize it

--- a/HARK/parallel.py
+++ b/HARK/parallel.py
@@ -241,8 +241,8 @@ def parallelNelderMead(objFunc,guess,perturb=None,P=1,ftol=0.000001,xtol=0.00000
     # Create the pool of worker processes
     cpu_cores = multiprocessing.cpu_count()  # Total number of available CPU cores
     cores_to_use = min(cpu_cores, dim_count)
-    if maxcores is not None:  # Cap the number of cores if desired
-        cores_to_use = min(cores_to_use, maxcores)
+    if maxthreads is not None:  # Cap the number of cores if desired
+        cores_to_use = min(cores_to_use, maxthreads)
     parallel = Parallel(n_jobs=cores_to_use)
 
     # Begin a new Nelder-Mead search


### PR DESCRIPTION
parallelNelderMead still refers to maxcores in its code, but the parameter is maxthreads; not sure how this even worked before.  Now fixed.