### PR TITLE
Bug fix to drawDiscrete

### DIFF
--- a/HARK/ConsumptionSaving/tests/test_ConsAggShockModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsAggShockModel.py
@@ -79,5 +79,5 @@ class testAggShockMarkovConsumerType(unittest.TestCase):
         
         self.economy.AFunc = self.economy.dynamics.AFunc
         self.assertAlmostEqual(self.economy.AFunc[0].slope,
-                         1.0921217053006234)
+                         1.0845554708377696)
                          

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -514,9 +514,9 @@ class DiscreteDistribution():
                 bot = top
                 top = cutoffs[j]
                 event_list += (top-bot)*[events[j]]
-                # Randomly permute the event indices and store the corresponding results
-                event_draws = RNG.permutation(event_list)
-                draws = X[event_draws]
+            # Randomly permute the event indices and store the corresponding results
+            event_draws = RNG.permutation(event_list)
+            draws = X[event_draws]
         else:
             indices = self.draw_events(N, seed=seed)
             if J > 1:


### PR DESCRIPTION
These two lines can be run outside the loop, avoiding an error when N<events.size and also saving time.
The error occurs when j=0 and event_draws is empty (X[event_draws] throws an error).