### PR TITLE
The change in how distributions are handled seems to have messed simulations up

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2496,7 +2496,8 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 ShkPrbsRet      = np.array([1.0])
             IncomeDstnRet = DiscreteDistribution(ShkPrbsRet,
                                                  [PermShkValsRet,
-                                                  TranShkValsRet])
+                                                  TranShkValsRet],
+                                                 seed=self.RNG.randint(0, 2**31-1))
 
         # Loop to fill in the list of IncomeDstn random variables.
         for t in range(T_cycle): # Iterate over all periods, counting forward
@@ -2518,7 +2519,9 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 ).approx(PermShkCount, tail_N=0)
                 ### REPLACE
                 ###REPLACE
-                IncomeDstn.append(combineIndepDstns(PermShkDstn_t,TranShkDstn_t)) # mix the independent distributions
+                IncomeDstn.append(combineIndepDstns(PermShkDstn_t,
+                                                    TranShkDstn_t,
+                                                    seed = self.RNG.randint(0, 2**31-1))) # mix the independent distributions
                 PermShkDstn.append(PermShkDstn_t)
                 TranShkDstn.append(TranShkDstn_t)
         return IncomeDstn, PermShkDstn, TranShkDstn

--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -353,7 +353,7 @@ class PortfolioConsumerType(IndShockConsumerType):
 
         mu = np.log(RiskyAvg / (np.sqrt(1. + RiskyVar / RiskyAvgSqrd)))
         sigma = np.sqrt(np.log(1. + RiskyVar / RiskyAvgSqrd))
-        self.RiskyNow = Lognormal(mu, sigma).draw(1, seed=self.RNG.randint(0, 2**31-1))
+        self.RiskyNow = Lognormal(mu, sigma, seed=self.RNG.randint(0, 2**31-1)).draw(1)
         
         
     def getAdjust(self):
@@ -370,7 +370,7 @@ class PortfolioConsumerType(IndShockConsumerType):
         -------
         None
         '''
-        self.AdjustNow = Bernoulli(self.AdjustPrb).draw(self.AgentCount, seed=self.RNG.randint(0, 2**31-1))
+        self.AdjustNow = Bernoulli(self.AdjustPrb, seed=self.RNG.randint(0, 2**31-1)).draw(self.AgentCount)
         
         
     def getRfree(self):

--- a/HARK/ConsumptionSaving/tests/test_ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsGenIncProcessModel.py
@@ -93,4 +93,4 @@ class testPersistentShockConsumerType(unittest.TestCase):
 
         self.assertAlmostEqual(
             np.mean(self.agent.history['mLvlNow']),
-            1.2063544810887799)
+            1.2043946738813716)

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -23,11 +23,11 @@ class testIndShockConsumerType(unittest.TestCase):
         self.agent.getShocks()
 
         self.assertEqual(self.agent.PermShkNow[0],
-                         0.9686755529883603)
+                         1.0427376294215103)
         self.assertEqual(self.agent.PermShkNow[1],
-                         1.0050166461586711)
+                         0.9278094171517413)
         self.assertEqual(self.agent.TranShkNow[0],
-                         1.2093790234554653)
+                         0.881761797501595)
 
     def test_ConsIndShockSolverBasic(self):
         LifecycleExample = IndShockConsumerType(
@@ -102,13 +102,11 @@ class testIndShockConsumerType(unittest.TestCase):
         self.agent.initializeSim()
         self.agent.simulate()
 
-        print(self.agent.aLvlNow)
-
         self.assertAlmostEqual(self.agent.MPCnow[1],
                                0.5711503906043797)
 
         self.assertAlmostEqual(self.agent.aLvlNow[1],
-                               0.21251164208206255)
+                               0.18438326264597635)
 
 
 class testBufferStock(unittest.TestCase):

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -824,7 +824,7 @@ def addDiscreteOutcome(distribution, x, p, sort = False):
 
     return DiscreteDistribution(pmf,X)
 
-def combineIndepDstns(*distributions):
+def combineIndepDstns(*distributions, seed=0):
     '''
     Given n lists (or tuples) whose elements represent n independent, discrete
     probability spaces (probabilities and values), construct a joint pmf over
@@ -897,4 +897,4 @@ def combineIndepDstns(*distributions):
     P_out = np.prod(np.array(P_temp),axis=0)
 
     assert np.isclose(np.sum(P_out),1),'Probabilities do not sum to 1!'
-    return DiscreteDistribution(P_out, X_out)
+    return DiscreteDistribution(P_out, X_out, seed = seed)


### PR DESCRIPTION
In my restoration of the CGMPortfolio remark, I think I've run into a couple of issues with RNG in simulations.

This PR deals with the fact that the random seed now has to be passed to the distribution's _init_ method and not the draw method.

However, my current simulated income paths look like this, which does not seem right
![image](https://user-images.githubusercontent.com/27739595/86408046-40f93400-bc84-11ea-8536-32e5521708e3.png)
It looks as if there was invididual-level variation in growth rates, but they stayed constant over time?

I'm looking into it but the income distribution RNG is more complicated so I wanted to ask if there is some obvious answer to what is going on there.

