### PR TITLE
tests in the Lognormal class to make sure mu and sigma have the same …

### DIFF
--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -57,6 +57,20 @@ class Lognormal(Distribution):
         # Set up the RNG
         super().__init__(seed)
 
+        if isinstance(self.mu, list) != isinstance(self.sigma, list):
+            raise Exception(
+                "mu and sigma must be of same types. They are %s, %s" % (
+                    type(self.mu), type(self.sigma)
+                    ))
+
+        if isinstance(self.mu, list):
+            if len(list(self.mu)) != len(list(self.sigma)):
+                raise Exception(
+                    "mu and sigma must be of same length, are %d, %d" % (
+                        len(list(self.mu)), len(list(self.sigma))
+                    ))
+
+
     def draw(self, N):
         '''
         Generate arrays of lognormal draws. The sigma input can be a number


### PR DESCRIPTION
This PR adds a couple exception handlers to the Lognormal class to check to make sure that if mu or sigma is a list, they are both lists, and are of the same length.

- [ ] Update CHANGELOG.md with major/minor changes.
