### PR TITLE
Considering agg. growth rate in checkGICInd

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2208,7 +2208,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
         '''
         Check Individual Growth Impatience Factor.
         '''
-        self.GPFInd = self.thorn/(self.PermGroFac[0]*self.InvEPermShkInv)  # [url]/#GICI
+        self.GPFInd = self.thorn/(self.PermGroFacAgg*self.PermGroFac[0]*self.InvEPermShkInv)  # [url]/#GICI
 
         name = 'GIC'
         test = lambda agent: agent.GPFInd <=1


### PR DESCRIPTION
"checkGICInd" in ConsIndShockModel should also take into account aggregate growth as given by parameter PermGroFacAgg. Discussed this with Chris yesterday, who suggested issuing a pull request with a potential fix.

Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->
- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
