### PR TITLE
adding simulation tests on consumption  for ConsPrefShockModel

### DIFF
--- a/HARK/ConsumptionSaving/tests/test_ConsPrefShockModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsPrefShockModel.py
@@ -39,6 +39,11 @@ class testPrefShockConsumerType(unittest.TestCase):
         self.agent.initializeSim()
         self.agent.simulate()
 
+        self.assertAlmostEqual(
+            self.agent.history['cNrmNow'][0][5],
+            1.21699840367737
+        )
+
 class testKinkyPrefConsumerType(unittest.TestCase):
 
     def setUp(self):
@@ -72,3 +77,8 @@ class testKinkyPrefConsumerType(unittest.TestCase):
         self.agent.track_vars = ["cNrmNow", "PrefShkNow"]
         self.agent.initializeSim()
         self.agent.simulate()
+
+        self.assertAlmostEqual(
+            self.agent.history['cNrmNow'][0][5],
+            1.3282880084862532
+        )


### PR DESCRIPTION
This PR adds a couple checks to the tests of ConsPrefShockModel simulation.
It compares the normalized consumption level with a preset value.