### PR TITLE
fixing seed of PrefShkDstn; changing tests to match

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -19,6 +19,7 @@ Release Data: TBD
 
 #### Minor Changes 
 
+* Fixes seed of PrefShkDstn on initialization and add tests for simulation output
 
 ### 0.10.7
 

--- a/HARK/ConsumptionSaving/ConsPrefShockModel.py
+++ b/HARK/ConsumptionSaving/ConsPrefShockModel.py
@@ -113,11 +113,15 @@ class PrefShockConsumerType(IndShockConsumerType):
         PrefShkDstn = [] # discrete distributions of preference shocks
         for t in range(len(self.PrefShkStd)):
             PrefShkStd = self.PrefShkStd[t]
-            new_dstn = MeanOneLogNormal(sigma=PrefShkStd).approx(
-                                                  N=self.PrefShkCount,
-                                                  tail_N=self.PrefShk_tail_N)
+            new_dstn = MeanOneLogNormal(
+                sigma=PrefShkStd,
+                seed = self.RNG.randint(0, 2**31-1)
+            ).approx(
+                N=self.PrefShkCount,
+                tail_N=self.PrefShk_tail_N,
+            )
             PrefShkDstn.append(new_dstn)
-                
+
         # Store the preference shocks in self (time-varying) and restore time flow
         self.PrefShkDstn = PrefShkDstn
         self.addToTimeVary('PrefShkDstn')

--- a/HARK/ConsumptionSaving/tests/test_ConsPrefShockModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsPrefShockModel.py
@@ -41,7 +41,7 @@ class testPrefShockConsumerType(unittest.TestCase):
 
         self.assertAlmostEqual(
             self.agent.history['cNrmNow'][0][5],
-            1.21699840367737
+            0.7366020536567589
         )
 
 class testKinkyPrefConsumerType(unittest.TestCase):
@@ -80,5 +80,5 @@ class testKinkyPrefConsumerType(unittest.TestCase):
 
         self.assertAlmostEqual(
             self.agent.history['cNrmNow'][0][5],
-            1.3282880084862532
+            0.7717096928111515
         )


### PR DESCRIPTION
Addressing a possible issue in ConsPrefShkModel, the seed given to the PrefShkDstn.
This change was recommended by @mnwhite 

This builds on #802, changing the test values.

This is related to work on #803 

<!--- Put an `x` in all the boxes that apply: -->
- [X] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [X] Update CHANGELOG.md with major/minor changes.
