### PR TITLE
manual symlinks for notebooks as directory symlinks don't work

### DIFF
--- a/Documentation/example_notebooks/ConsPortfolioModel.ipynb
+++ b/Documentation/example_notebooks/ConsPortfolioModel.ipynb
@@ -1,0 +1,1 @@
+../../examples/ConsPortfolioModel/ConsPortfolioModel.ipynb

--- a/Documentation/example_notebooks/GenIncProcessModel.ipynb
+++ b/Documentation/example_notebooks/GenIncProcessModel.ipynb
@@ -1,0 +1,1 @@
+../../examples/GenIncProcessModel/GenIncProcessModel.ipynb

--- a/Documentation/example_notebooks/Gentle-Intro-To-HARK.ipynb
+++ b/Documentation/example_notebooks/Gentle-Intro-To-HARK.ipynb
@@ -1,0 +1,1 @@
+../../examples/Gentle-Intro/Gentle-Intro-To-HARK.ipynb

--- a/Documentation/example_notebooks/HowWeSolveIndShockConsumerType.ipynb
+++ b/Documentation/example_notebooks/HowWeSolveIndShockConsumerType.ipynb
@@ -1,0 +1,1 @@
+../../examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.ipynb

--- a/Documentation/example_notebooks/IndShockConsumerType.ipynb
+++ b/Documentation/example_notebooks/IndShockConsumerType.ipynb
@@ -1,0 +1,1 @@
+../../examples/ConsIndShockModel/IndShockConsumerType.ipynb

--- a/Documentation/example_notebooks/Journey_1_PhD.ipynb
+++ b/Documentation/example_notebooks/Journey_1_PhD.ipynb
@@ -1,0 +1,1 @@
+../../examples/Journeys/Journey_1_PhD.ipynb

--- a/Documentation/example_notebooks/KinkedRconsumerType.ipynb
+++ b/Documentation/example_notebooks/KinkedRconsumerType.ipynb
@@ -1,0 +1,1 @@
+../../examples/ConsIndShockModel/KinkedRconsumerType.ipynb

--- a/Documentation/example_notebooks/LifecycleModel.ipynb
+++ b/Documentation/example_notebooks/LifecycleModel.ipynb
@@ -1,0 +1,1 @@
+../../examples/LifecycleModel/LifecycleModel.ipynb

--- a/Documentation/examples
+++ b/Documentation/examples
@@ -1,1 +1,0 @@
-../examples/

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -30,16 +30,15 @@ you might want to look at the `DemARK
    :maxdepth: 1
    :caption: Notebooks
 
-   examples/Gentle-Intro/Gentle-Intro-To-HARK.ipynb
-   examples/ConsIndShockModel/PerfForesightConsumerType.ipynb
-   examples/ConsIndShockModel/IndShockConsumerType.ipynb
-   examples/ConsIndShockModel/KinkedRconsumerType.ipynb
-   examples/ConsumptionSaving/example_ConsPortfolioModel.ipynb
-   examples/GenIncProcessModel/GenIncProcessModel.ipynb
-   examples/LifecycleModel/LifecycleModel.ipynb
-   examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.ipynb
-   examples/Journeys/Journey_1_PhD.ipynb
-
+   example_notebooks/Gentle-Intro-To-HARK.ipynb
+   example_notebooks/PerfForesigthConsumerType.ipynb
+   example_notebooks/IndShockConsumerType.ipynb
+   example_notebooks/KinkedRconsumerType.ipynb
+   example_notebooks/ConsPortfolioModel.ipynb
+   example_notebooks/GenIncProcessModel.ipynb
+   example_notebooks/LifecycleModel.ipynb
+   example_notebooks/HowWeSolveIndShockConsumerType.ipynb
+   example_notebooks/Journey_1_PhD.ipynb
 
 Indices and tables
 ==================


### PR DESCRIPTION
fixes https://github.com/econ-ark/HARK/issues/839

In the revamp I over-rode the manual fix for symlinks in documentation directory, symlinks should be for individual notebooks not the whole examples directory.