### PR TITLE
apache2.0 is the valid license key for Zenodo not Apache-2.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,7 +14,7 @@
       "name": "Kaufman, Alexander"
   }],
   "access_right": "open", 
-  "license": "Apache-2.0",
+  "license": "apache2.0",
   "upload_type": "software", 
     "related_identifiers": [
         {


### PR DESCRIPTION
This should fix the zenodo issues, but we would need to wait till the next release to check this out.
I am still looking for a way to backport this fix to old releases so we have a clean history of releases
available on Zenodo, just like on PyPI.
