### PR TITLE
Use getattr to execute commands instead of exec

### DIFF
--- a/HARK/parallel.py
+++ b/HARK/parallel.py
@@ -27,7 +27,8 @@ def multiThreadCommandsFake(
     """
     for agent in agent_list:
         for command in command_list:
-            exec("agent." + command)
+            # TODO: Code should be updated to pass in the method name instead of method()
+            getattr(agent, command[:-2])()
 
 
 def multiThreadCommands(agent_list: List, command_list: List, num_jobs=None) -> None:
@@ -84,5 +85,6 @@ def runCommands(agent: Any, command_list: List) -> Any:
         The same AgentType instance passed as input, after running the commands.
     """
     for command in command_list:
-        exec("agent." + command)
+        # TODO: Code should be updated to pass in the method name instead of method()
+        getattr(agent, command[:-2])()
     return agent


### PR DESCRIPTION
Fixes https://github.com/econ-ark/HARK/issues/851

The code still contains a "hack" to strip the last two characters `()` from all the methods passed to `multiThreadCommands(Fake)`. Ideally going forward we should only pass in the name of the method in the list of commands. `[solve, initializeSim, simulate]` instead of `[solve(), initializeSim(), simulate()]`.

Should I refactor instances of this in the codebase for the next release or should we wait atleast for a 0.10.8 release.

If we move to `[solve, initializeSim, simulate]` this will break a bunch of REMARKs.