### PR TITLE
namespace for control variables

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -17,6 +17,7 @@ Release Data: TBD
 * Namespace variables for the Market class [#765](https://github.com/econ-ark/HARK/pull/765)
 * We now have a Numba based implementation of PerfForesightConsumerType model available as PerfForesightConsumerTypeFast [#774](https://github.com/econ-ark/HARK/pull/774)
 * Namespace for exogenous shocks [#803](https://github.com/econ-ark/HARK/pull/803)
+* Namespace for controls [#855](https://github.com/econ-ark/HARK/pull/855)
 * State and poststate attributes replaced with state_now and state_prev namespaces [#836](https://github.com/econ-ark/HARK/pull/836)
 
 #### Minor Changes 

--- a/HARK/ConsumptionSaving/ConsAggShockModel.py
+++ b/HARK/ConsumptionSaving/ConsAggShockModel.py
@@ -382,7 +382,8 @@ class AggShockConsumerType(IndShockConsumerType):
             MPCnow[these] = self.solution[t].cFunc.derivativeX(
                 self.state_now["mNrmNow"][these], MaggNow[these]
             )  # Marginal propensity to consume
-        self.cNrmNow = cNrmNow
+
+        self.controls["cNrmNow"] = cNrmNow
         self.MPCnow = MPCnow
         return None
 
@@ -625,7 +626,7 @@ class AggShockMarkovConsumerType(AggShockConsumerType):
                     .cFunc[i]
                     .derivativeX(self.state_now["mNrmNow"][those], MaggNow[those])
                 )
-        self.cNrmNow = cNrmNow
+        self.controls["cNrmNow"] = cNrmNow
         self.MPCnow = MPCnow
         return None
 
@@ -1040,13 +1041,13 @@ class KrusellSmithType(AgentType):
         cNow[employed] = self.solution[0].cFunc[emp_idx](
             self.state_now["mNow"][employed], Mnow[employed]
         )
-        self.cNow = cNow
+        self.controls["cNow"] = cNow
 
     def getPostStates(self):
         """
         Gets each agent's retained assets after consumption and stores MrkvNow as MrkvPrev.
         """
-        self.state_now['aNow'] = self.state_now["mNow"] - self.cNow
+        self.state_now['aNow'] = self.state_now["mNow"] - self.controls["cNow"]
         self.MrkvPrev = self.MrkvNow
 
 

--- a/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
@@ -1372,7 +1372,7 @@ class GenIncProcessConsumerType(IndShockConsumerType):
             MPCnow[these] = self.solution[t].cFunc.derivativeX(
                 self.state_now["mLvlNow"][these], self.state_now["pLvlNow"][these]
             )
-        self.cLvlNow = cLvlNow
+        self.controls["cLvlNow"] = cLvlNow
         self.MPCnow = MPCnow
 
     def getPostStates(self):
@@ -1388,7 +1388,7 @@ class GenIncProcessConsumerType(IndShockConsumerType):
         -------
         None
         """
-        self.state_now['aLvlNow'] = self.state_now["mLvlNow"] - self.cLvlNow
+        self.state_now['aLvlNow'] = self.state_now["mLvlNow"] - self.controls["cLvlNow"]
         # moves now to prev
         AgentType.getPostStates(self)
 

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -1817,7 +1817,9 @@ class PerfForesightConsumerType(AgentType):
             cNrmNow[these], MPCnow[these] = self.solution[t].cFunc.eval_with_derivative(
                 self.state_now['mNrmNow'][these]
             )
-        self.cNrmNow = cNrmNow
+        self.controls['cNrmNow'] = cNrmNow
+
+        # MPCnow is not really a control
         self.MPCnow = MPCnow
         return None
 
@@ -1834,7 +1836,7 @@ class PerfForesightConsumerType(AgentType):
         None
         """
         # should this be "Now", or "Prev"?!?
-        self.state_now['aNrmNow'] = self.state_now['mNrmNow'] - self.cNrmNow
+        self.state_now['aNrmNow'] = self.state_now['mNrmNow'] - self.controls['cNrmNow']
         # Useful in some cases to precalculate asset level
         self.state_now['aLvlNow'] = self.state_now['aNrmNow'] * self.state_now['pLvlNow']
 

--- a/HARK/ConsumptionSaving/ConsLaborModel.py
+++ b/HARK/ConsumptionSaving/ConsLaborModel.py
@@ -516,9 +516,9 @@ class LaborIntMargConsumerType(IndShockConsumerType):
             LbrNow[these] = self.solution[t].LbrFunc(
                 self.state_now['bNrmNow'][these], self.shocks["TranShkNow"][these]
             )  # Assign labor supply
-        self.cNrmNow = cNrmNow
+        self.controls['cNrmNow'] = cNrmNow
         self.MPCnow = MPCnow
-        self.LbrNow = LbrNow
+        self.controls['LbrNow'] = LbrNow
 
     def getPostStates(self):
         """
@@ -538,9 +538,9 @@ class LaborIntMargConsumerType(IndShockConsumerType):
             these = t == self.t_cycle
             mNrmNow[these] = (
                 self.state_now['bNrmNow'][these]
-                + self.LbrNow[these] * self.shocks["TranShkNow"][these]
+                + self.controls['LbrNow'][these] * self.shocks["TranShkNow"][these]
             )  # mNrm = bNrm + yNrm
-            aNrmNow[these] = mNrmNow[these] - self.cNrmNow[these]  # aNrm = mNrm - cNrm
+            aNrmNow[these] = mNrmNow[these] - self.controls['cNrmNow'][these]  # aNrm = mNrm - cNrm
         self.state_now['mNrmNow'] = mNrmNow
         self.state_now['aNrmNow'] = aNrmNow
 

--- a/HARK/ConsumptionSaving/ConsMarkovModel.py
+++ b/HARK/ConsumptionSaving/ConsMarkovModel.py
@@ -1185,7 +1185,7 @@ class MarkovConsumerType(IndShockConsumerType):
                 cNrmNow[these], MPCnow[these] = (
                     self.solution[t].cFunc[j].eval_with_derivative(self.state_now['mNrmNow'][these])
                 )
-        self.cNrmNow = cNrmNow
+        self.controls["cNrmNow"] = cNrmNow
         self.MPCnow = MPCnow
 
     def calcBoundingValues(self):

--- a/HARK/ConsumptionSaving/ConsMedModel.py
+++ b/HARK/ConsumptionSaving/ConsMedModel.py
@@ -852,7 +852,7 @@ class MedShockConsumerType(PersistentShockConsumerType):
                 MedShkNow[these] = self.MedShkDstn[t].drawDiscrete(N)
                 MedPriceNow[these] = self.MedPrice[t]
         self.shocks["MedShkNow"] = MedShkNow
-        self.MedPriceNow = MedPriceNow
+        self.shocks["MedPriceNow"] = MedPriceNow
 
     def getControls(self):
         """
@@ -876,8 +876,8 @@ class MedShockConsumerType(PersistentShockConsumerType):
                 self.state_now['pLvlNow'][these],
                 self.shocks["MedShkNow"][these],
             )
-        self.cLvlNow = cLvlNow
-        self.MedNow = MedNow
+        self.controls['cLvlNow'] = cLvlNow
+        self.controls['MedNow'] = MedNow
         return None
 
     def getPostStates(self):
@@ -892,7 +892,7 @@ class MedShockConsumerType(PersistentShockConsumerType):
         -------
         None
         """
-        self.state_now['aLvlNow'] = self.state_now['mLvlNow'] - self.cLvlNow - self.MedPriceNow * self.MedNow
+        self.state_now['aLvlNow'] = self.state_now['mLvlNow'] - self.controls['cLvlNow'] - self.shocks["MedPriceNow"] * self.controls['MedNow']
 
         # moves now to prev
         AgentType.getPostStates(self)

--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -406,7 +406,7 @@ class PortfolioConsumerType(IndShockConsumerType):
             return factor.  Will be used by getStates() to calculate mNrmNow, where it
             will be mislabeled as "Rfree".
         """
-        Rport = self.ShareNow * self.shocks['RiskyNow'] + (1.0 - self.ShareNow) * self.Rfree
+        Rport = self.controls["ShareNow"] * self.shocks['RiskyNow'] + (1.0 - self.controls["ShareNow"]) * self.Rfree
         self.RportNow = Rport
         return Rport
 
@@ -425,7 +425,7 @@ class PortfolioConsumerType(IndShockConsumerType):
         """
         # these need to be set because "post states",
         # but are a control variable and shock, respectively
-        self.ShareNow = np.zeros(self.AgentCount)
+        self.controls["ShareNow"] = np.zeros(self.AgentCount)
         self.shocks['AdjustNow'] = np.zeros(self.AgentCount, dtype=bool)
         IndShockConsumerType.initializeSim(self)
 
@@ -506,8 +506,8 @@ class PortfolioConsumerType(IndShockConsumerType):
             )
 
         # Store controls as attributes of self
-        self.cNrmNow = cNrmNow
-        self.ShareNow = ShareNow
+        self.controls["cNrmNow"] = cNrmNow
+        self.controls["ShareNow"] = ShareNow
 
 
 # Define a non-object-oriented one period solver

--- a/HARK/ConsumptionSaving/ConsPrefShockModel.py
+++ b/HARK/ConsumptionSaving/ConsPrefShockModel.py
@@ -207,7 +207,7 @@ class PrefShockConsumerType(IndShockConsumerType):
             cNrmNow[these] = self.solution[t].cFunc(
                 self.state_now['mNrmNow'][these], self.shocks["PrefShkNow"][these]
             )
-        self.cNrmNow = cNrmNow
+        self.controls['cNrmNow'] = cNrmNow
         return None
 
     def calcBoundingValues(self):

--- a/HARK/ConsumptionSaving/ConsRepAgentModel.py
+++ b/HARK/ConsumptionSaving/ConsRepAgentModel.py
@@ -392,7 +392,7 @@ class RepAgentMarkovConsumerType(RepAgentConsumerType):
         """
         t = self.t_cycle[0]
         i = self.MrkvNow[0]
-        self.cNrmNow = self.solution[t].cFunc[i](self.mNrmNow)
+        self.controls["cNrmNow"] = self.solution[t].cFunc[i](self.mNrmNow)
 
 
 # Define the default dictionary for a representative agent type

--- a/HARK/ConsumptionSaving/TractableBufferStockModel.py
+++ b/HARK/ConsumptionSaving/TractableBufferStockModel.py
@@ -681,7 +681,7 @@ class TractableConsumerType(AgentType):
         cLvlNow = np.zeros(self.AgentCount)
         cLvlNow[employed] = self.solution[0].cFunc(self.state_now['mLvlNow'][employed])
         cLvlNow[unemployed] = self.solution[0].cFunc_U(self.state_now['mLvlNow'][unemployed])
-        self.cLvlNow = cLvlNow
+        self.controls["cLvlNow"] = cLvlNow
 
     def getPostStates(self):
         """
@@ -695,7 +695,7 @@ class TractableConsumerType(AgentType):
         -------
         None
         """
-        self.state_now['aLvlNow'] = self.state_now['mLvlNow'] - self.cLvlNow
+        self.state_now['aLvlNow'] = self.state_now['mLvlNow'] - self.controls["cLvlNow"]
         return None
 
 

--- a/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
@@ -51,11 +51,11 @@ class UnitsPortfolioConsumerTypeTestCase(PortfolioConsumerTypeTestCase):
         self.pcct.simOnePeriod()
 
         self.assertAlmostEqual(
-            self.pcct.ShareNow[0],
+            self.pcct.controls["ShareNow"][0],
             0.8627164488246847
         )
         self.assertAlmostEqual(
-            self.pcct.cNrmNow[0],
+            self.pcct.controls["cNrmNow"][0],
             1.67874799
         )
 

--- a/HARK/core.py
+++ b/HARK/core.py
@@ -233,6 +233,7 @@ class AgentType(HARKobject):
         self.track_vars = []  # NOQA
         self.state_now = {sv : None for sv in self.state_vars}
         self.state_prev = self.state_now.copy()
+        self.controls = {}
         self.shocks = {}
         self.read_shocks = False  # NOQA
         self.shock_history = {}
@@ -783,6 +784,8 @@ class AgentType(HARKobject):
                         ]
                     elif var_name in self.shocks:
                         self.history[var_name][self.t_sim, :] = self.shocks[var_name]
+                    elif var_name in self.controls:
+                        self.history[var_name][self.t_sim, :] = self.controls[var_name]
                     else:
                         self.history[var_name][self.t_sim, :] = getattr(self, var_name)
                 self.t_sim += 1


### PR DESCRIPTION
This puts each 'control' variable into a namespace, `controls`, similar to `shocks`.

It does not adjust the storage to use '_now' or '_prev' dictionaries for the controls.
We can discuss this choice in the meeting -- fore example, whether we prefer to put all the 'model variables' including shocks and controls into 'now' and 'prev' dicts.

This is passing tests locally.

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
