### PR TITLE
Fixing bugs in documentation

### DIFF
--- a/Documentation/example_notebooks/ConsPortfolioModel.ipynb
+++ b/Documentation/example_notebooks/ConsPortfolioModel.ipynb
@@ -1,1 +1,0 @@
-../../examples/ConsPortfolioModel/ConsPortfolioModel.ipynb

--- a/Documentation/reference/ConsumptionSaving/ConsIndShockFastModel.rst
+++ b/Documentation/reference/ConsumptionSaving/ConsIndShockFastModel.rst
@@ -1,7 +1,0 @@
-ConsIndShockFastModel
-----------------------------
-
-.. automodule:: HARK.ConsumptionSaving.ConsIndShockFastModel
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/Documentation/reference/ConsumptionSaving/ConsIndShockModelFast.rst
+++ b/Documentation/reference/ConsumptionSaving/ConsIndShockModelFast.rst
@@ -1,0 +1,7 @@
+ConsIndShockModelFast
+----------------------------
+
+.. automodule:: HARK.ConsumptionSaving.ConsIndShockModelFast
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/Documentation/reference/tools/index.rst
+++ b/Documentation/reference/tools/index.rst
@@ -12,6 +12,5 @@ Tools
    interpolation
    parallel
    simulation
-   solver
    utilities
    validators

--- a/Documentation/reference/tools/solver.rst
+++ b/Documentation/reference/tools/solver.rst
@@ -1,7 +1,0 @@
-Solver
-------------
-
-.. automodule:: HARK.solver
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.ipynb
+++ b/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.ipynb
@@ -457,7 +457,38 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.5"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.py
+++ b/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.py
@@ -5,8 +5,8 @@
 #     text_representation:
 #       extension: .py
 #       format_name: percent
-#       format_version: '1.2'
-#       jupytext_version: 1.2.4
+#       format_version: '1.3'
+#       jupytext_version: 1.6.0
 #   kernelspec:
 #     display_name: Python 3
 #     language: python


### PR DESCRIPTION
Fixes to the documentation.
Clears up some build warnings.

Also, fixes typo in name of "How We Solve" notebook that was preventing it from rendering in RTD.
Should fix #858 