### PR TITLE
docs fixes

### DIFF
--- a/Documentation/example_notebooks/PerfForesightConsumerType.ipynb
+++ b/Documentation/example_notebooks/PerfForesightConsumerType.ipynb
@@ -1,0 +1,1 @@
+../../examples/ConsIndShockModel/PerfForesightConsumerType.ipynb

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -31,7 +31,7 @@ you might want to look at the `DemARK
    :caption: Notebooks
 
    example_notebooks/Gentle-Intro-To-HARK.ipynb
-   example_notebooks/PerfForesigthConsumerType.ipynb
+   example_notebooks/PerfForesightConsumerType.ipynb
    example_notebooks/IndShockConsumerType.ipynb
    example_notebooks/KinkedRconsumerType.ipynb
    example_notebooks/ConsPortfolioModel.ipynb

--- a/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.ipynb
+++ b/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.ipynb
@@ -338,7 +338,7 @@
     {
      "data": {
       "text/plain": [
-       "<HARK.ConsumptionSaving.ConsIndShockModel.ConsumerSolution at 0x7f16ba1095f8>"
+       "<HARK.ConsumptionSaving.ConsIndShockModel.ConsumerSolution at 0x7f406e4a9748>"
       ]
      },
      "execution_count": 11,

--- a/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.ipynb
+++ b/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.ipynb
@@ -93,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Let's try it in action!\n",
+    "## Let's try it in action!\n",
     "First, we define a standard lifecycle model, solve it and then"
    ]
   },
@@ -457,7 +457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.9"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.py
+++ b/examples/HowWeSolveIndShockConsumerType/HowWeSolveIndShockConsumerType.py
@@ -5,8 +5,8 @@
 #     text_representation:
 #       extension: .py
 #       format_name: percent
-#       format_version: '1.3'
-#       jupytext_version: 1.6.0
+#       format_version: '1.2'
+#       jupytext_version: 1.2.4
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -95,7 +95,7 @@
 # We are now done, but in the `ConsIndShockSolver` (non-`Basic`!) solver there are a few extra steps. We add steady state m, and depending on the values of `vFuncBool` and `CubicBool` we also add the value function and the marginal marginal value function.
 
 # %% [markdown]
-# # Let's try it in action!
+# ## Let's try it in action!
 # First, we define a standard lifecycle model, solve it and then
 
 # %%

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 matplotlib
-sphinx==1.6.7
+sphinx
 future
 joblib
 dill
@@ -10,7 +10,7 @@ jupyter
 funcsigs
 jupyter
 sphinx-rtd-theme
-nbsphinx==0.4.3
+nbsphinx
 seaborn
 recommonmark
 interpolation

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ python_requires = >=3.6
 
 [options.extras_require]
 dev =  
-    Sphinx<=1.6.7
+    Sphinx
     nbsphinx
     recommonmark
     pre-commit


### PR DESCRIPTION
More to fix #858 

This unpins the Sphinx and nbsphinx dependencies in `requirements.txt` which is what RTD is using for its build environment.

On my `sbenthall:sb-docs` branch, the How We Solve notebook is now rendering properly. 

Since we're short staffed and this is an urgent issue, I'll merge it once tests pass.