### PR TITLE
rewrite calcExpectation to use numpy methods, see #625

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -16,7 +16,7 @@ Release Data: TBD
 
 * Adds a constructor for LogNormal distributions from mean and standard deviation (#891)[https://github.com/econ-ark/HARK/pull/891/]
 * Uses new LogNormal constructor in ConsPortfolioModel (#891)[https://github.com/econ-ark/HARK/pull/891/]
-* calcExpectations method for taking the expectation of a distribution over a function (#884)[https://github.com/econ-ark/HARK/pull/884/]
+* calcExpectations method for taking the expectation of a distribution over a function (#884)[https://github.com/econ-ark/HARK/pull/884/] (#897)[https://github.com/econ-ark/HARK/pull/897]
 
 
 #### Minor Changes

--- a/HARK/tests/test_distribution.py
+++ b/HARK/tests/test_distribution.py
@@ -3,6 +3,18 @@ import unittest
 
 import HARK.distribution as distribution
 
+from HARK.distribution import (
+    Bernoulli,
+    DiscreteDistribution,
+    Lognormal,
+    MeanOneLogNormal,
+    Normal,
+    Uniform,
+    Weibull,
+    calcExpectation,
+    combineIndepDstns
+)
+
 
 class DiscreteDistributionTests(unittest.TestCase):
     """
@@ -12,12 +24,79 @@ class DiscreteDistributionTests(unittest.TestCase):
 
     def test_drawDiscrete(self):
         self.assertEqual(
-            distribution.DiscreteDistribution(np.ones(1), np.zeros(1)).drawDiscrete(1)[
+            DiscreteDistribution(
+                np.ones(1),
+                np.zeros(1)).drawDiscrete(1)[
                 0
             ],
             0,
         )
 
+    def test_calcExpectation(self):
+        dd_0_1_20 = Normal().approx(20)
+        dd_1_1_40 = Normal(mu = 1).approx(40)
+        dd_10_10_100 = Normal(mu = 10, sigma = 10).approx(100)
+
+        ce1 = calcExpectation(dd_0_1_20)
+        ce2 = calcExpectation(dd_1_1_40)
+        ce3 = calcExpectation(dd_10_10_100)
+
+        self.assertAlmostEqual(ce1, 0.0)
+        self.assertAlmostEqual(ce2, 1.0)
+        self.assertAlmostEqual(ce3, 10.0)
+
+        ce4= calcExpectation(
+            dd_0_1_20,
+            lambda x: 2 ** x
+        )
+
+        self.assertAlmostEqual(ce4, 1.27153712)
+
+        ce5 = calcExpectation(
+            dd_1_1_40,
+            lambda x: 2 * x
+        )
+
+        self.assertAlmostEqual(ce5, 2.0)
+
+        ce6 = calcExpectation(
+            dd_10_10_100,
+            lambda x, y: 2 * x + y,
+            20
+        )
+
+        self.assertAlmostEqual(ce6, 40.0)
+
+        ce7 = calcExpectation(
+            dd_0_1_20,
+            lambda x, y: x + y,
+            np.hstack(np.array([0,1,2,3,4,5]))
+        )
+
+        self.assertAlmostEqual(ce7.flat[3], 3.0)
+
+        PermShkDstn = MeanOneLogNormal().approx(200)
+        TranShkDstn = MeanOneLogNormal().approx(200)
+        IncomeDstn = combineIndepDstns(PermShkDstn, TranShkDstn)
+
+        ce8 = calcExpectation(
+            IncomeDstn,
+            lambda X: X[0] + X[1]
+        )
+
+        self.assertAlmostEqual(ce8, 2.0)
+
+        ce9 = calcExpectation(
+            IncomeDstn,
+            lambda X, a, r: r / X[0] * a + X[1],
+            np.array([0,1,2,3,4,5]), # an aNrmNow grid?
+            1.05 # an interest rate?
+        )
+
+        self.assertAlmostEqual(
+            ce9[3][0],
+            9.518015322143837
+        )
 
 class DistributionClassTests(unittest.TestCase):
     """
@@ -26,11 +105,11 @@ class DistributionClassTests(unittest.TestCase):
     """
 
     def test_drawMeanOneLognormal(self):
-        self.assertEqual(distribution.MeanOneLogNormal().draw(1)[0], 3.5397367004222002)
+        self.assertEqual(MeanOneLogNormal().draw(1)[0], 3.5397367004222002)
 
     def test_Lognormal(self):
 
-        dist = distribution.Lognormal()
+        dist = Lognormal()
 
         self.assertEqual(dist.draw(1)[0], 5.836039190663969)
 
@@ -40,7 +119,7 @@ class DistributionClassTests(unittest.TestCase):
         self.assertEqual(dist.draw(1)[0], 5.836039190663969)
 
     def test_Normal(self):
-        dist = distribution.Normal()
+        dist = Normal()
 
         self.assertEqual(dist.draw(1)[0], 1.764052345967664)
 
@@ -50,17 +129,23 @@ class DistributionClassTests(unittest.TestCase):
         self.assertEqual(dist.draw(1)[0], 1.764052345967664)
 
     def test_Weibull(self):
-        self.assertEqual(distribution.Weibull().draw(1)[0], 0.79587450816311)
+        self.assertEqual(
+            Weibull().draw(1)[0],
+            0.79587450816311)
 
     def test_Uniform(self):
-        uni = distribution.Uniform()
-
-        self.assertEqual(distribution.Uniform().draw(1)[0], 0.5488135039273248)
+        uni = Uniform()
 
         self.assertEqual(
-            distribution.calcExpectation(uni.approx(10))[0],
+            Uniform().draw(1)[0],
+            0.5488135039273248)
+
+        self.assertEqual(
+            calcExpectation(uni.approx(10)),
             0.5
         )
 
     def test_Bernoulli(self):
-        self.assertEqual(distribution.Bernoulli().draw(1)[0], False)
+        self.assertEqual(
+            Bernoulli().draw(1)[0], False
+        )


### PR DESCRIPTION
This rewrites `calcExpectation` to use `numpy.apply_along_axis`.
It is a _much_ more succinct implementation.

This rewritten version does not compute the tensor product in cases of multiple 1D value inputs.
I have argued in #625 that this should be handled by a different method outside of the `calcExpectation` function.

What this PR lacks in terms of functionality compared to the first implementation, it makes up for in automated tests.
This PR includes tests, including for multivariate distributions with both array and constant non-stochastic values.

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
