### PR TITLE
Add tests for "Stable Points"

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -673,7 +673,7 @@ class ConsPerfForesightSolver(HARKobject):
         # only if this is the case.
         thorn = (self.Rfree*self.DiscFacEff)**(1/self.CRRA)
         GIC = 1 > thorn/self.PermGroFac
-        if self.BoroCnstArt and GIC:
+        if self.BoroCnstArt is not None and GIC:
             solution = self.addSSmNrm(solution)
             solution = self.addmNrmTrg(solution)
     

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -391,6 +391,6 @@ class testStablePoints(unittest.TestCase):
         mNrmSS = baseAgent_Inf.solution[0].mNrmSS
         mNrmTrg = baseAgent_Inf.solution[0].mNrmTrg
         
-        # Checka against pre-computed values
+        # Check against pre-computed values
         self.assertAlmostEqual(mNrmSS , 1.3773113386500273)
         self.assertAlmostEqual(mNrmTrg, 1.3910165380594735)

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -357,3 +357,40 @@ class testIndShockConsumerTypeCyclical(unittest.TestCase):
         self.assertAlmostEqual(
             CyclicalExample.solution[3].cFunc(3).tolist(), 1.5958390056965004
         )
+
+# %% Tests of 'stable points'
+
+# Create the base infinite horizon parametrization from the "Buffer Stock
+# Theory" paper.
+bst_params = copy(init_idiosyncratic_shocks)
+bst_params['PermGroFac']   = [1.03] # Permanent income growth factor
+bst_params['Rfree']        = 1.04  # Interest factor on assets
+bst_params['DiscFac']      = 0.96  # Time Preference Factor
+bst_params['CRRA']         = 2.00  # Coefficient of relative risk aversion
+bst_params['UnempPrb']     = 0.005 # Probability of unemployment (e.g. Probability of Zero Income in the paper)
+bst_params['IncUnemp']     = 0.0   # Induces natural borrowing constraint
+bst_params['PermShkStd']   = [0.1]   # Standard deviation of log permanent income shocks
+bst_params['TranShkStd']   = [0.1]   # Standard deviation of log transitory income shocks
+bst_params['LivPrb']       = [1.0]   # 100 percent probability of living to next period
+bst_params['CubicBool']    = True    # Use cubic spline interpolation
+bst_params['T_cycle']      = 1       # No 'seasonal' cycles
+bst_params['BoroCnstArt']  = None    # No artificial borrowing constraint
+
+class testStablePoints(unittest.TestCase):
+    
+    def test_IndShock_stable_points(self):
+        # Test for the target and individual steady state of the infinite
+        # horizon solution using the parametrization in the "Buffer Stock
+        # Theory" paper.
+        
+        # Create and solve the agent
+        baseAgent_Inf = IndShockConsumerType(cycles=0,verbose=0, **bst_params)
+        baseAgent_Inf.solve()
+        
+        # Extract stable points
+        mNrmSS = baseAgent_Inf.solution[0].mNrmSS
+        mNrmTrg = baseAgent_Inf.solution[0].mNrmTrg
+        
+        # Checka against pre-computed values
+        self.assertAlmostEqual(mNrmSS , 1.3773113386500273)
+        self.assertAlmostEqual(mNrmTrg, 1.3910165380594735)

--- a/HARK/ConsumptionSaving/tests/test_PerfForesightConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_PerfForesightConsumerType.py
@@ -7,7 +7,8 @@ class testPerfForesightConsumerType(unittest.TestCase):
     def setUp(self):
         self.agent = PerfForesightConsumerType()
         self.agent_infinite = PerfForesightConsumerType(cycles=0)
-
+        self.agent_constrained = PerfForesightConsumerType(cycles = 0, BoroCnstArt = 0.0)
+        
         PF_dictionary = {
             "CRRA": 2.5,
             "DiscFac": 0.96,
@@ -100,3 +101,15 @@ class testPerfForesightConsumerType(unittest.TestCase):
             np.mean(self.agent_infinite.history["mNrmNow"], axis=1)[100],
             -29.140261331951606,
         )
+        
+    def test_stable_points(self):
+        
+        # Solve the constrained agent. Stable points exists only with a
+        # borrowing constraint.
+        self.agent_constrained.solve()
+        
+        # Check against pre-computed values.
+        self.assertEqual(self.agent_constrained.solution[0].mNrmSS , 1.0)
+        # Check that they are both the same, since the problem is deterministic
+        self.assertEqual(self.agent_constrained.solution[0].mNrmSS,
+                         self.agent_constrained.solution[0].mNrmTrg)

--- a/HARK/ConsumptionSaving/tests/test_PerfForesightConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_PerfForesightConsumerType.py
@@ -7,7 +7,6 @@ class testPerfForesightConsumerType(unittest.TestCase):
     def setUp(self):
         self.agent = PerfForesightConsumerType()
         self.agent_infinite = PerfForesightConsumerType(cycles=0)
-        self.agent_constrained = PerfForesightConsumerType(cycles = 0, BoroCnstArt = 0.0)
         
         PF_dictionary = {
             "CRRA": 2.5,
@@ -106,10 +105,12 @@ class testPerfForesightConsumerType(unittest.TestCase):
         
         # Solve the constrained agent. Stable points exists only with a
         # borrowing constraint.
-        self.agent_constrained.solve()
+        constrained_agent = PerfForesightConsumerType(cycles = 0, BoroCnstArt = 0.0)
+        
+        constrained_agent.solve()
         
         # Check against pre-computed values.
-        self.assertEqual(self.agent_constrained.solution[0].mNrmSS , 1.0)
+        self.assertEqual(constrained_agent.solution[0].mNrmSS , 1.0)
         # Check that they are both the same, since the problem is deterministic
-        self.assertEqual(self.agent_constrained.solution[0].mNrmSS,
-                         self.agent_constrained.solution[0].mNrmTrg)
+        self.assertEqual(constrained_agent.solution[0].mNrmSS,
+                         constrained_agent.solution[0].mNrmTrg)


### PR DESCRIPTION
This PR adds tests for the calculation of stable points in the `IndShock` and `PerfForesight` models. The `IndShock` tests use the model from the Buffer stock theory paper.

It fixes a couple of bugs encountered while creating the tests (yay tests):
- `addStablePoints` was in `ConsIndShockSolver` and not `ConsIndShockSolverBasic`, so the points were computed only when cubic interpolation was being used.
- While checking the conditions for existence of stable points in the perfect foresight model, `BoroCnstArt` was treated as a boolean, but it is a float.

<!--- Put an `x` in all the boxes that apply: -->
- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
