### PR TITLE
MrkvNow into model state shocks['Mrkv'] in AggShockMarkov and KrusellSmith models

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -27,6 +27,8 @@ interpolation for problems with CRRA utility. See [#888](https://github.com/econ
 * Fix the return fields of `dcegm/calcCrossPoints`[#909](https://github.com/econ-ark/HARK/pull/909).
 * Corrects location of constructor documentation to class string for Sphinx rendering [#908](https://github.com/econ-ark/HARK/pull/908)
 * Adds a module for producing life-cycle profiles of income shock variances from [Sabelhaus and Song (2010)](https://www.sciencedirect.com/science/article/abs/pii/S0304393210000358). See [#921](https://github.com/econ-ark/HARK/pull/921).
+* Moves state MrkvNow to shocks['Mrkv'] in AggShockMarkov and KrusellSmith models [#935](https://github.com/econ-ark/HARK/pull/935)
+
 #### Minor Changes
 
 * Move AgentType constructor parameters docs to class docstring so it is rendered by Sphinx.

--- a/HARK/ConsumptionSaving/ConsAggShockModel.py
+++ b/HARK/ConsumptionSaving/ConsAggShockModel.py
@@ -493,6 +493,9 @@ class AggShockMarkovConsumerType(AggShockConsumerType):
         params.update(kwds)
         kwds = params
         AggShockConsumerType.__init__(self, **kwds)
+
+        self.shocks['Mrkv'] = None
+
         self.addToTimeInv("MrkvArray")
         self.solveOnePeriod = solveConsAggMarkov
 
@@ -566,7 +569,7 @@ class AggShockMarkovConsumerType(AggShockConsumerType):
             N = np.sum(these)
             if N > 0:
                 IncShkDstnNow = self.IncShkDstn[t - 1][
-                    self.MrkvNow
+                    self.shocks['Mrkv']
                 ]  # set current income distribution
                 PermGroFacNow = self.PermGroFac[t - 1]  # and permanent growth factor
 
@@ -582,7 +585,7 @@ class AggShockMarkovConsumerType(AggShockConsumerType):
         if N > 0:
             these = newborn
             IncShkDstnNow = self.IncShkDstn[0][
-                self.MrkvNow
+                self.shocks['Mrkv']
             ]  # set current income distribution
             PermGroFacNow = self.PermGroFac[0]  # and permanent growth factor
 
@@ -642,7 +645,7 @@ class AggShockMarkovConsumerType(AggShockConsumerType):
         return None
 
     def getMrkvNow(self):  # This function exists to be overwritten in StickyE model
-        return self.MrkvNow * np.ones(self.AgentCount, dtype=int)
+        return self.shocks['Mrkv'] * np.ones(self.AgentCount, dtype=int)
 
 
 init_KS_agents = {
@@ -1067,7 +1070,7 @@ class KrusellSmithType(AgentType):
 
     def getPostStates(self):
         """
-        Gets each agent's retained assets after consumption and stores MrkvNow as MrkvPrev.
+        Gets each agent's retained assets after consumption.
         """
         self.state_now['aNow'] = self.state_now["mNow"] - self.controls["cNow"]
 
@@ -2404,7 +2407,7 @@ class CobbDouglasMarkovEconomy(CobbDouglasEconomy):
             "PermShkAggNow",
             "TranShkAggNow",
             "KtoLnow",
-            "MrkvNow",  # This one is new
+            "Mrkv",  # This one is new
         ],
         **kwds
     ):
@@ -2421,7 +2424,7 @@ class CobbDouglasMarkovEconomy(CobbDouglasEconomy):
             **params
         )
 
-        self.sow_init["MrkvNow"] = params["MrkvNow_init"]
+        self.sow_init["Mrkv"] = params["MrkvNow_init"]
 
     def update(self):
         """
@@ -2593,7 +2596,7 @@ class CobbDouglasMarkovEconomy(CobbDouglasEconomy):
         MrkvNow_hist = np.zeros(self.act_T_orig, dtype=int)
         loops = 0
         go = True
-        MrkvNow = self.sow_init["MrkvNow"]
+        MrkvNow = self.sow_init["Mrkv"]
         t = 0
         StateCount = self.MrkvArray.shape[0]
 

--- a/HARK/ConsumptionSaving/tests/test_ConsAggShockModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsAggShockModel.py
@@ -263,6 +263,6 @@ class KrusellSmithEconomyTestCase(KrusellSmithTestCase):
 
         self.assertAlmostEqual(self.economy.history["Aprev"][4], 11.009107526443584)
 
-        self.assertAlmostEqual(self.economy.history["MrkvNow"][40], 1)
+        self.assertAlmostEqual(self.economy.history["Mrkv"][40], 1)
 
         self.assertAlmostEqual(self.economy.history["Urate"][12], 0.040000000000000036)

--- a/HARK/core.py
+++ b/HARK/core.py
@@ -533,8 +533,12 @@ class AgentType(Model):
         # state_{t-1}
         for var in self.state_now:
             self.state_prev[var] = self.state_now[var]
-            # note: this is not type checked for aggregate variables.
-            self.state_now[var] = np.empty(self.AgentCount)
+
+            if isinstance(self.state_now[var], np.ndarray):
+                self.state_now[var] = np.empty(self.AgentCount)
+            else:
+                # Probably an aggregate variable. It may be getting set by the Market.
+                pass
 
         if self.read_shocks:  # If shock histories have been pre-specified, use those
             self.readShocks()
@@ -1251,6 +1255,8 @@ class Market(Model):
             for this_type in self.agents:
                 if sow_var in this_type.state_now:
                     this_type.state_now[sow_var] = self.sow_state[sow_var]
+                if sow_var in this_type.shocks:
+                    this_type.shocks[sow_var] = self.sow_state[sow_var]
                 else:
                     setattr(this_type, sow_var, self.sow_state[sow_var])
 


### PR DESCRIPTION
Fixes #933.

In the AggShockMarkov and KrusellSmith agents and associated economies, the `MrkvNow` property was being set as an object attribute, despite being a model variable. It's an aggregate property in both cases.

This PR replaces these with a shock `Mrkv`. This is small progress towards #920, which otherwise can be done with simple search-and-replace operations.

`Mrkv` is a shock and not a state in this implementation because the way Market interactions with the Agent currently works, if the Market sets and agent state in its `sow` step, it will be rolled over into the `state_prev` namespace during the simulation in the `cultivate` step. Because here the `Mrkv` state really is exogenous to the agent, `shocks` seems more appropriate, though I hope we can scaffold this a bit better in, say, v1.1

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
