### PR TITLE
DiscreteDistribution keeps link to parent ContinuousDistribution

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -31,6 +31,7 @@ interpolation for problems with CRRA utility. See [#888](https://github.com/econ
 * remove "Now" from model variable names [#936](https://github.com/econ-ark/HARK/pull/936)
 * Moves state MrkvNow to shocks['Mrkv'] in AggShockMarkov and KrusellSmith models [#935](https://github.com/econ-ark/HARK/pull/935)
 * Replaces `ConsIndShock`'s `init_lifecycle` with an actual life-cycle calibration [#951](https://github.com/econ-ark/HARK/pull/951).
+* New ContinuousDistribution class; DiscreteDistribution now tracks Continuous parent and approximation parameters [#954](https://github.com/econ-ark/HARK/pull/954)
 
 #### Minor Changes
 

--- a/HARK/tests/test_distribution.py
+++ b/HARK/tests/test_distribution.py
@@ -118,6 +118,16 @@ class DistributionClassTests(unittest.TestCase):
 
         self.assertEqual(dist.draw(1)[0], 5.836039190663969)
 
+        self.assertEqual(
+            dist.approx(5).approx_args[0],
+            5
+        )
+
+        self.assertEqual(
+            dist.approx(10).parent.sigma,
+            1.0
+        )
+
     def test_Normal(self):
         dist = Normal()
 
@@ -139,6 +149,16 @@ class DistributionClassTests(unittest.TestCase):
         self.assertEqual(
             Uniform().draw(1)[0],
             0.5488135039273248)
+
+        self.assertEqual(
+            uni.approx(10).approx_args[0],
+            10
+        )
+
+        self.assertEqual(
+            uni.approx(10).parent.top,
+            1.0
+        )
 
         self.assertEqual(
             calcExpectation(uni.approx(10)),


### PR DESCRIPTION
fixes #949

- New `ContinuousDistribution` class
- `approx` method on this class calls a method `pmf_X` (should be renamed...) which is overridden by subclasses
- DiscreteDistributions created with `approx` link back to their parent continuous distribution with arguments to `approx` method
- new tests for this functionality, changelog update included.

Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->
- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
