### PR TITLE
Add csv's to MANIFEST.in

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -42,6 +42,7 @@ interpolation for problems with CRRA utility. See [#888](https://github.com/econ
 * AgentType simulate() method now returns history. [#916](https://github.com/econ-ark/HARK/pull/916)
 * Rename DiscreteDistribution.drawDiscrete() to draw()
 * Update documentation and warnings around IncShkDstn [#955](https://github.com/econ-ark/HARK/pull/955)
+* Adds csv files to `MANIFEST.in`. [957](https://github.com/econ-ark/HARK/pull/957)
 
 ### 0.10.8
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,7 @@ include MANIFEST.in
 include setup.cfg
 
 # include data files
-recursive-include HARK/datasets/data *.txt
+recursive-include HARK/datasets/data *.txt *.csv
 
 # except build files
 global-exclude *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,8 @@ include MANIFEST.in
 include setup.cfg
 
 # include data files
-recursive-include HARK/datasets/data *.txt *.csv
+recursive-include HARK/datasets/data *.txt
+recursive-include HARK/datasets *.csv
 
 # except build files
 global-exclude *.pyc


### PR DESCRIPTION
My recent calibration tools added a couple datasets in csv format to the toolbox.

However, I had no idea these needed to be in the `MANIFEST.in` file to get collected when one installs HARK.

I noticed the issue while messing around with some conda environments for a cluster, and wondering why my tools were not working after installing HARK.

This tiny pr fixes the issue. It is my first time working with `MANIFEST.in`, could someone review?

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
