### PR TITLE
utilities.determine_platform() should return, e.g., linux

### DIFF
--- a/HARK/utilities.py
+++ b/HARK/utilities.py
@@ -844,7 +844,7 @@ def determine_platform():
     """
     import platform
 
-    pform = platform.platform().lower()
+    pform = platform.system().lower()
     if "darwin" in pform:
         pf = "darwin"  # MacOS
     elif "debian" in pform:


### PR DESCRIPTION
HARK.utilities.determine_platform() should have been returning, e.g., linux or darwin or windows.  Instead it was returning and extremely detailed string with TMI.  This fixes that.
