### PR TITLE
Fix type-related bug in DCEGM

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -8,6 +8,16 @@ For more information on HARK, see [our Github organization](https://github.com/e
 
 ## Changes
 
+### 0.12.0
+
+Release Data: TBD
+
+#### Major Changes
+
+#### Minor Changes
+
+* Fix bug in DCEGM's primary kink finder due to numpy no longer accepting NaN in integer arrays [#990](https://github.com/econ-ark/HARK/pull/990).
+
 ### 0.11.0
 
 Release Data: March 4, 2021

--- a/HARK/dcegm.py
+++ b/HARK/dcegm.py
@@ -114,8 +114,7 @@ def calc_prim_kink(mGrid, vTGrids, choices):
     """
 
     # Construct a vector with the optimal choice at each m point
-    optChoice = np.empty(len(mGrid), dtype=int)
-    optChoice[:] = np.nan
+    optChoice = np.zeros_like(mGrid, dtype=int)
     for i in range(len(vTGrids)):
         idx = choices[i] == 1
         optChoice[idx] = i


### PR DESCRIPTION
Recent versions of numpy became more strict with respect to data types. Particularly, np.NaN is no longer accepted in integer arrays. This was causing a crash in the DCEGM code whenever it was used with numpy 1.2.0 (which the binder instances do). For instance [the DCEGM DemArk binder link](https://mybinder.org/v2/gh/econ-ark/DemARK/master?filepath=notebooks/DCEGM-Upper-Envelope.ipynb) crashes.

This PR fixes the issue.

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
