### PR TITLE
use Lognormal.from_mean_std in RiskyAsset forward simulation

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -21,6 +21,7 @@ PR: [#832](https://github.com/econ-ark/HARK/pull/832). See [this forthcoming REM
 
 #### Minor Changes
 
+* Using Lognormal.from_mean_std in the forward simulation of the RiskyAsset model [#1019](https://github.com/econ-ark/HARK/pull/1019)
 * Fix bug in DCEGM's primary kink finder due to numpy no longer accepting NaN in integer arrays [#990](https://github.com/econ-ark/HARK/pull/990).
 * Add a general class for consumers who can save using a risky asset [#1012](https://github.com/econ-ark/HARK/pull/1012/).
 

--- a/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
@@ -184,13 +184,9 @@ class RiskyAssetConsumerType(IndShockConsumerType):
         else:
             RiskyAvg = self.RiskyAvg
             RiskyStd = self.RiskyStd
-        RiskyAvgSqrd = RiskyAvg ** 2
-        RiskyVar = RiskyStd ** 2
 
-        mu = np.log(RiskyAvg / (np.sqrt(1.0 + RiskyVar / RiskyAvgSqrd)))
-        sigma = np.sqrt(np.log(1.0 + RiskyVar / RiskyAvgSqrd))
-        self.shocks["Risky"] = Lognormal(
-            mu, sigma, seed=self.RNG.randint(0, 2 ** 31 - 1)
+        self.shocks["Risky"] = Lognormal.from_mean_std(
+            self.RiskyAvg, self.RiskyStd, seed=self.RNG.randint(0, 2 ** 31 - 1)
         ).draw(1)
 
     def get_Adjust(self):

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -181,11 +181,11 @@ class Lognormal(Distribution):
     Parameters
     ----------
     mu : float or [float]
-        One or more means.  Number of elements T in mu determines number
-        of rows of output.
+        One or more means of underlying normal distribution.
+        Number of elements T in mu determines number of rows of output.
     sigma : float or [float]
-        One or more standard deviations. Number of elements T in sigma
-        determines number of rows of output.
+        One or more standard deviations of underlying normal distribution.
+        Number of elements T in sigma determines number of rows of output.
     seed : int
         Seed for random number generator.
     """


### PR DESCRIPTION
fixes #1003

<!--- Put an `x` in all the boxes that apply: -->
- [x ] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
