### PR TITLE
[WIP] cleaning up strange newborn handling in ConsIndShock model

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2171,9 +2171,12 @@ class IndShockConsumerType(PerfForesightConsumerType):
         """
         PermShkNow = np.zeros(self.AgentCount)  # Initialize shock arrays
         TranShkNow = np.zeros(self.AgentCount)
-        newborn = self.t_age == 0
-        for t in range(self.T_cycle):
-            these = t == self.t_cycle
+
+        draw_age = self.t_cycle - 1
+        draw_age[draw_age < 0] = 0
+
+        for t in np.unique(draw_age):
+            these = t == draw_age
             N = np.sum(these)
             if N > 0:
                 IncShkDstnNow = self.IncShkDstn[
@@ -2187,23 +2190,6 @@ class IndShockConsumerType(PerfForesightConsumerType):
                     IncShks[0, :] * PermGroFacNow
                 )  # permanent "shock" includes expected growth
                 TranShkNow[these] = IncShks[1, :]
-
-        # That procedure used the *last* period in the sequence for newborns, but that's not right
-        # Redraw shocks for newborns, using the *first* period in the sequence.  Approximation.
-        N = np.sum(newborn)
-        if N > 0:
-            these = newborn
-            IncShkDstnNow = self.IncShkDstn[0]  # set current income distribution
-            PermGroFacNow = self.PermGroFac[0]  # and permanent growth factor
-
-            # Get random draws of income shocks from the discrete distribution
-            EventDraws = IncShkDstnNow.draw_events(N)
-            PermShkNow[these] = (
-                IncShkDstnNow.X[0][EventDraws] * PermGroFacNow
-            )  # permanent "shock" includes expected growth
-            TranShkNow[these] = IncShkDstnNow.X[1][EventDraws]
-        #        PermShkNow[newborn] = 1.0
-        TranShkNow[newborn] = 1.0
 
         # Store the shocks in self
         self.EmpNow = np.ones(self.AgentCount, dtype=bool)


### PR DESCRIPTION
The current handling of newborn income shocks is convoluted and prevents extensibility.

It is also apparently motivated by the improper inclusion of a hack needed for particular use case, StickyE, into the general library. See #326 

This PR introduces some numpy array logic that cuts several confusing lines of code as well as correcting for this issue #326 

I would actually advocate for further streamlining this code before merging.

However, tampering with this part of code should get some discussion and review. There's no way to make these fixes without changing the way in which the income process distributions are being sampled. That means that _all_ the numerical values used in the tests for models that inherit from IndShockConsumerType will be thrown off by these changes.

Correcting those numerical values is something I'm happy to do to improve the code clarity.

<!--- Put an `x` in all the boxes that apply: -->
- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
