### PR TITLE
[WIP] Rounding numbers with many decimals in tests

### DIFF
--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -1,12 +1,14 @@
+import unittest
+from copy import copy
+
+import numpy as np
+
 from HARK.ConsumptionSaving.ConsIndShockModel import (
     IndShockConsumerType,
     ConsIndShockSolverBasic,
     init_lifecycle,
     init_idiosyncratic_shocks,
 )
-import numpy as np
-import unittest
-from copy import copy
 
 
 class testIndShockConsumerType(unittest.TestCase):
@@ -23,9 +25,9 @@ class testIndShockConsumerType(unittest.TestCase):
 
         self.agent.get_shocks()
 
-        self.assertEqual(self.agent.shocks['PermShk'][0], 1.0427376294215103)
-        self.assertEqual(self.agent.shocks['PermShk'][1], 0.9278094171517413)
-        self.assertEqual(self.agent.shocks['TranShk'][0], 0.881761797501595)
+        self.assertAlmostEqual(self.agent.shocks["PermShk"][0], 1.04273763)
+        self.assertAlmostEqual(self.agent.shocks["PermShk"][1], 0.92780942)
+        self.assertAlmostEqual(self.agent.shocks["TranShk"][0], 0.88176180)
 
     def test_ConsIndShockSolverBasic(self):
         LifecycleExample = IndShockConsumerType(**init_lifecycle)
@@ -40,13 +42,13 @@ class testIndShockConsumerType(unittest.TestCase):
         self.assertAlmostEqual(LifecycleExample.solution[7].cFunc(1), 0.79253095)
 
         self.assertAlmostEqual(
-            LifecycleExample.solution[0].cFunc(1).tolist(), 0.7506184692092213
+            LifecycleExample.solution[0].cFunc(1).tolist(), 0.75061847
         )
         self.assertAlmostEqual(
-            LifecycleExample.solution[1].cFunc(1).tolist(), 0.7586358637239385
+            LifecycleExample.solution[1].cFunc(1).tolist(), 0.75863586
         )
         self.assertAlmostEqual(
-            LifecycleExample.solution[2].cFunc(1).tolist(), 0.7681247572911291
+            LifecycleExample.solution[2].cFunc(1).tolist(), 0.76812476
         )
 
         solver = ConsIndShockSolverBasic(
@@ -65,36 +67,35 @@ class testIndShockConsumerType(unittest.TestCase):
 
         solver.prepare_to_solve()
 
-        self.assertAlmostEqual(solver.DiscFacEff, 0.9586233599999999)
-        self.assertAlmostEqual(solver.PermShkMinNext, 0.6554858756904397)
+        self.assertAlmostEqual(solver.DiscFacEff, 0.95862336)
+        self.assertAlmostEqual(solver.PermShkMinNext, 0.65548588)
         self.assertAlmostEqual(solver.cFuncNowCnst(4).tolist(), 4.0)
-        self.assertAlmostEqual(solver.prepare_to_calc_EndOfPrdvP()[0], -0.19792871012285213)
-        self.assertAlmostEqual(solver.prepare_to_calc_EndOfPrdvP()[-1], 19.801071289877118)
+        self.assertAlmostEqual(solver.prepare_to_calc_EndOfPrdvP()[0], -0.19792871)
+        self.assertAlmostEqual(solver.prepare_to_calc_EndOfPrdvP()[-1], 19.80107129)
 
         EndOfPrdvP = solver.calc_EndOfPrdvP()
 
-        self.assertAlmostEqual(EndOfPrdvP[0], 6657.839372100613)
-        self.assertAlmostEqual(EndOfPrdvP[-1], 0.2606075215645896)
+        self.assertAlmostEqual(EndOfPrdvP[0], 6657.83937210)
+        self.assertAlmostEqual(EndOfPrdvP[-1], 0.26060752)
 
         solution = solver.make_basic_solution(
             EndOfPrdvP, solver.aNrmNow, solver.make_linear_cFunc
         )
         solver.add_MPC_and_human_wealth(solution)
 
-        self.assertAlmostEqual(solution.cFunc(4).tolist(), 1.0028005137373956)
+        self.assertAlmostEqual(solution.cFunc(4).tolist(), 1.00280051)
 
     def test_simulated_values(self):
         self.agent.initialize_sim()
         self.agent.simulate()
 
-        self.assertAlmostEqual(self.agent.MPCnow[1], 0.5711503906043797)
+        self.assertAlmostEqual(self.agent.MPCnow[1], 0.57115039)
 
-        self.assertAlmostEqual(self.agent.state_now['aLvl'][1], 0.18438326264597635)
+        self.assertAlmostEqual(self.agent.state_now["aLvl"][1], 0.18438326)
 
 
 class testBufferStock(unittest.TestCase):
-    """ Tests of the results of the BufferStock REMARK.
-    """
+    """Tests of the results of the BufferStock REMARK."""
 
     def setUp(self):
         # Make a dictionary containing all parameters needed to solve the model
@@ -129,12 +130,12 @@ class testBufferStock(unittest.TestCase):
         c_t5 = baseEx.cFunc[-6](m)
         c_t10 = baseEx.cFunc[-11](m)
 
-        self.assertAlmostEqual(c_m[500], 1.4008090582203356)
-        self.assertAlmostEqual(c_t1[500], 2.9227437159255216)
-        self.assertAlmostEqual(c_t5[500], 1.7350607327187664)
-        self.assertAlmostEqual(c_t10[500], 1.4991390649979213)
-        self.assertAlmostEqual(c_t10[600], 1.6101476268581576)
-        self.assertAlmostEqual(c_t10[700], 1.7196531041366991)
+        self.assertAlmostEqual(c_m[500], 1.40080906)
+        self.assertAlmostEqual(c_t1[500], 2.92274372)
+        self.assertAlmostEqual(c_t5[500], 1.73506073)
+        self.assertAlmostEqual(c_t10[500], 1.49913906)
+        self.assertAlmostEqual(c_t10[600], 1.61014763)
+        self.assertAlmostEqual(c_t10[700], 1.71965310)
 
     def test_GICRawFails(self):
         GICRaw_fail_dictionary = dict(self.base_params)
@@ -151,8 +152,8 @@ class testBufferStock(unittest.TestCase):
         m = np.linspace(0, 5, 1000)
         c_m = GICRawFailExample.cFunc[0](m)
 
-        self.assertAlmostEqual(c_m[500], 0.7772637042393458)
-        self.assertAlmostEqual(c_m[700], 0.8392649061916746)
+        self.assertAlmostEqual(c_m[500], 0.77726370)
+        self.assertAlmostEqual(c_m[700], 0.83926491)
 
         self.assertFalse(GICRawFailExample.conditions["GICRaw"])
 
@@ -167,22 +168,22 @@ class testBufferStock(unittest.TestCase):
         )  # m1 defines the plot range on the left of target m value (e.g. m <= target m)
         c_m1 = baseEx_inf.cFunc[0](m1)
 
-        self.assertAlmostEqual(c_m1[0], 0.8527887545025995)
-        self.assertAlmostEqual(c_m1[-1], 1.0036279936408656)
+        self.assertAlmostEqual(c_m1[0], 0.85278875)
+        self.assertAlmostEqual(c_m1[-1], 1.00362799)
 
         x1 = np.linspace(0, 25, 1000)
         cfunc_m = baseEx_inf.cFunc[0](x1)
 
-        self.assertAlmostEqual(cfunc_m[500], 1.8902146173138235)
-        self.assertAlmostEqual(cfunc_m[700], 2.1591451850267176)
+        self.assertAlmostEqual(cfunc_m[500], 1.89021462)
+        self.assertAlmostEqual(cfunc_m[700], 2.15914519)
 
         m = np.linspace(0.001, 8, 1000)
 
         # Use the HARK method derivative to get the derivative of cFunc, and the values are just the MPC
         MPC = baseEx_inf.cFunc[0].derivative(m)
 
-        self.assertAlmostEqual(MPC[500], 0.08415000641504392)
-        self.assertAlmostEqual(MPC[700], 0.07173144137912524)
+        self.assertAlmostEqual(MPC[500], 0.08415001)
+        self.assertAlmostEqual(MPC[700], 0.07173144)
 
 
 IdiosyncDict = {
@@ -232,18 +233,16 @@ class testIndShockConsumerTypeExample(unittest.TestCase):
         IndShockExample.cycles = 0  # Make this type have an infinite horizon
         IndShockExample.solve()
 
-        self.assertAlmostEqual(IndShockExample.solution[0].mNrmStE, 1.5488165705077026)
+        self.assertAlmostEqual(IndShockExample.solution[0].mNrmStE, 1.54881657)
         self.assertAlmostEqual(
             IndShockExample.solution[0].cFunc.functions[0].x_list[0], -0.25017509
         )
 
-        IndShockExample.track_vars = ['aNrm', "mNrm", "cNrm", 'pLvl']
+        IndShockExample.track_vars = ["aNrm", "mNrm", "cNrm", "pLvl"]
         IndShockExample.initialize_sim()
         IndShockExample.simulate()
 
-        self.assertAlmostEqual(
-            IndShockExample.history["mNrm"][0][0], 1.0170176090252379
-        )
+        self.assertAlmostEqual(IndShockExample.history["mNrm"][0][0], 1.01701761)
 
 
 LifecycleDict = {  # Click arrow to expand this fairly large parameter dictionary
@@ -303,7 +302,7 @@ class testIndShockConsumerTypeLifecycle(unittest.TestCase):
         )
 
         self.assertAlmostEqual(
-            LifecycleExample.solution[5].cFunc(3).tolist(), 2.129983771775666
+            LifecycleExample.solution[5].cFunc(3).tolist(), 2.12998377
         )
 
 
@@ -355,8 +354,9 @@ class testIndShockConsumerTypeCyclical(unittest.TestCase):
         CyclicalExample.solve()
 
         self.assertAlmostEqual(
-            CyclicalExample.solution[3].cFunc(3).tolist(), 1.5958390056965004
+            CyclicalExample.solution[3].cFunc(3).tolist(), 1.59583901
         )
+
 
 # %% Tests of 'stable points'
 
@@ -364,23 +364,22 @@ class testIndShockConsumerTypeCyclical(unittest.TestCase):
 # Create the base infinite horizon parametrization from the "Buffer Stock
 # Theory" paper.
 bst_params = copy(init_idiosyncratic_shocks)
-bst_params['PermGroFac'] = [1.03]  # Permanent income growth factor
-bst_params['Rfree'] = 1.04  # Interest factor on assets
-bst_params['DiscFac'] = 0.96  # Time Preference Factor
-bst_params['CRRA'] = 2.00  # Coefficient of relative risk aversion
+bst_params["PermGroFac"] = [1.03]  # Permanent income growth factor
+bst_params["Rfree"] = 1.04  # Interest factor on assets
+bst_params["DiscFac"] = 0.96  # Time Preference Factor
+bst_params["CRRA"] = 2.00  # Coefficient of relative risk aversion
 # Probability of unemployment (e.g. Probability of Zero Income in the paper)
-bst_params['UnempPrb'] = 0.005
-bst_params['IncUnemp'] = 0.0   # Induces natural borrowing constraint
-bst_params['PermShkStd'] = [0.1]   # Standard deviation of log permanent income shocks
-bst_params['TranShkStd'] = [0.1]   # Standard deviation of log transitory income shocks
-bst_params['LivPrb'] = [1.0]   # 100 percent probability of living to next period
-bst_params['CubicBool'] = True    # Use cubic spline interpolation
-bst_params['T_cycle'] = 1       # No 'seasonal' cycles
-bst_params['BoroCnstArt'] = None    # No artificial borrowing constraint
+bst_params["UnempPrb"] = 0.005
+bst_params["IncUnemp"] = 0.0  # Induces natural borrowing constraint
+bst_params["PermShkStd"] = [0.1]  # Standard deviation of log permanent income shocks
+bst_params["TranShkStd"] = [0.1]  # Standard deviation of log transitory income shocks
+bst_params["LivPrb"] = [1.0]  # 100 percent probability of living to next period
+bst_params["CubicBool"] = True  # Use cubic spline interpolation
+bst_params["T_cycle"] = 1  # No 'seasonal' cycles
+bst_params["BoroCnstArt"] = None  # No artificial borrowing constraint
 
 
 class testStablePoints(unittest.TestCase):
-
     def test_IndShock_stable_points(self):
         # Test for the target and individual steady state of the infinite
         # horizon solution using the parametrization in the "Buffer Stock
@@ -395,6 +394,6 @@ class testStablePoints(unittest.TestCase):
         mNrmTrg = baseAgent_Inf.solution[0].mNrmTrg
 
         # Check against pre-computed values
-        decimalPlacesTo = 10
-        self.assertAlmostEqual(mNrmStE, 1.37731133865, decimalPlacesTo)
-        self.assertAlmostEqual(mNrmTrg, 1.39101653806, decimalPlacesTo)
+        decimalPlacesTo = 8
+        self.assertAlmostEqual(mNrmStE, 1.37731134, decimalPlacesTo)
+        self.assertAlmostEqual(mNrmTrg, 1.39101654, decimalPlacesTo)

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerTypeFast.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerTypeFast.py
@@ -1,6 +1,8 @@
 import unittest
 from copy import copy
+
 import numpy as np
+
 from HARK.ConsumptionSaving.ConsIndShockModel import (
     init_lifecycle,
     init_idiosyncratic_shocks,
@@ -27,9 +29,9 @@ class testIndShockConsumerTypeFast(unittest.TestCase):
 
         self.agent.get_shocks()
 
-        self.assertEqual(self.agent.shocks['PermShk'][0], 1.0427376294215103)
-        self.assertEqual(self.agent.shocks['PermShk'][1], 0.9278094171517413)
-        self.assertEqual(self.agent.shocks['TranShk'][0], 0.881761797501595)
+        self.assertAlmostEqual(self.agent.shocks["PermShk"][0], 1.04273763)
+        self.assertAlmostEqual(self.agent.shocks["PermShk"][1], 0.92780942)
+        self.assertAlmostEqual(self.agent.shocks["TranShk"][0], 0.88176180)
 
     def test_ConsIndShockSolverBasic(self):
         LifecycleExample = IndShockConsumerTypeFast(**init_lifecycle)
@@ -44,26 +46,25 @@ class testIndShockConsumerTypeFast(unittest.TestCase):
         self.assertAlmostEqual(LifecycleExample.solution[7].cFunc(1), 0.79253095)
 
         self.assertAlmostEqual(
-            LifecycleExample.solution[0].cFunc(1).tolist(), 0.7506184692092213
+            LifecycleExample.solution[0].cFunc(1).tolist(), 0.75061847
         )
         self.assertAlmostEqual(
-            LifecycleExample.solution[1].cFunc(1).tolist(), 0.7586358637239385
+            LifecycleExample.solution[1].cFunc(1).tolist(), 0.75863586
         )
         self.assertAlmostEqual(
-            LifecycleExample.solution[2].cFunc(1).tolist(), 0.7681247572911291
+            LifecycleExample.solution[2].cFunc(1).tolist(), 0.76812476
         )
 
     def test_simulated_values(self):
         self.agent.initialize_sim()
         self.agent.simulate()
-        self.assertAlmostEqual(self.agent.MPCnow[1], 0.5711503906043797)
+        self.assertAlmostEqual(self.agent.MPCnow[1], 0.57115039)
 
-        self.assertAlmostEqual(self.agent.state_now['aLvl'][1], 0.18438326264597635)
+        self.assertAlmostEqual(self.agent.state_now["aLvl"][1], 0.18438326)
 
 
 class testBufferStock(unittest.TestCase):
-    """ Tests of the results of the BufferStock REMARK.
-    """
+    """Tests of the results of the BufferStock REMARK."""
 
     def setUp(self):
         # Make a dictionary containing all parameters needed to solve the model
@@ -98,12 +99,12 @@ class testBufferStock(unittest.TestCase):
         c_t5 = baseEx.cFunc[-6](m)
         c_t10 = baseEx.cFunc[-11](m)
 
-        self.assertAlmostEqual(c_m[500], 1.4008090582203356)
-        self.assertAlmostEqual(c_t1[500], 2.9227437159255216)
-        self.assertAlmostEqual(c_t5[500], 1.7350607327187664)
-        self.assertAlmostEqual(c_t10[500], 1.4991390649979213)
-        self.assertAlmostEqual(c_t10[600], 1.6101476268581576)
-        self.assertAlmostEqual(c_t10[700], 1.7196531041366991)
+        self.assertAlmostEqual(c_m[500], 1.40080906)
+        self.assertAlmostEqual(c_t1[500], 2.92274372)
+        self.assertAlmostEqual(c_t5[500], 1.73506073)
+        self.assertAlmostEqual(c_t10[500], 1.49913906)
+        self.assertAlmostEqual(c_t10[600], 1.61014763)
+        self.assertAlmostEqual(c_t10[700], 1.71965310)
 
     def test_GICRawFails(self):
         GICRaw_fail_dictionary = dict(self.base_params)
@@ -120,8 +121,8 @@ class testBufferStock(unittest.TestCase):
         m = np.linspace(0, 5, 1000)
         c_m = GICRawFailExample.cFunc[0](m)
 
-        self.assertAlmostEqual(c_m[500], 0.7772637042393458)
-        self.assertAlmostEqual(c_m[700], 0.8392649061916746)
+        self.assertAlmostEqual(c_m[500], 0.77726370)
+        self.assertAlmostEqual(c_m[700], 0.83926491)
 
         self.assertFalse(GICRawFailExample.conditions["GICRaw"])
 
@@ -136,22 +137,22 @@ class testBufferStock(unittest.TestCase):
         )  # m1 defines the plot range on the left of target m value (e.g. m <= target m)
         c_m1 = baseEx_inf.cFunc[0](m1)
 
-        self.assertAlmostEqual(c_m1[0], 0.8527887545025995)
-        self.assertAlmostEqual(c_m1[-1], 1.0036279936408656)
+        self.assertAlmostEqual(c_m1[0], 0.85278875)
+        self.assertAlmostEqual(c_m1[-1], 1.00362799)
 
         x1 = np.linspace(0, 25, 1000)
         cfunc_m = baseEx_inf.cFunc[0](x1)
 
-        self.assertAlmostEqual(cfunc_m[500], 1.8902146173138235)
-        self.assertAlmostEqual(cfunc_m[700], 2.1591451850267176)
+        self.assertAlmostEqual(cfunc_m[500], 1.89021462)
+        self.assertAlmostEqual(cfunc_m[700], 2.15914519)
 
         m = np.linspace(0.001, 8, 1000)
 
         # Use the HARK method derivative to get the derivative of cFunc, and the values are just the MPC
         MPC = baseEx_inf.cFunc[0].derivative(m)
 
-        self.assertAlmostEqual(MPC[500], 0.08415000641504392)
-        self.assertAlmostEqual(MPC[700], 0.07173144137912524)
+        self.assertAlmostEqual(MPC[500], 0.08415001)
+        self.assertAlmostEqual(MPC[700], 0.07173144)
 
 
 class testIndShockConsumerTypeFastExample(unittest.TestCase):
@@ -160,18 +161,16 @@ class testIndShockConsumerTypeFastExample(unittest.TestCase):
         IndShockExample.cycles = 0  # Make this type have an infinite horizon
         IndShockExample.solve()
 
-        self.assertAlmostEqual(IndShockExample.solution[0].mNrmStE, 1.5488165705077026)
+        self.assertAlmostEqual(IndShockExample.solution[0].mNrmStE, 1.54881657)
         self.assertAlmostEqual(
             IndShockExample.solution[0].cFunc.functions[0].x_list[0], -0.25017509
         )
 
-        IndShockExample.track_vars = ['aNrm', "mNrm", 'cNrm', 'pLvl']
+        IndShockExample.track_vars = ["aNrm", "mNrm", "cNrm", "pLvl"]
         IndShockExample.initialize_sim()
         IndShockExample.simulate()
 
-        self.assertAlmostEqual(
-            IndShockExample.history["mNrm"][0][0], 1.0170176090252379
-        )
+        self.assertAlmostEqual(IndShockExample.history["mNrm"][0][0], 1.01701761)
 
 
 class testIndShockConsumerTypeFastLifecycle(unittest.TestCase):
@@ -190,7 +189,7 @@ class testIndShockConsumerTypeFastLifecycle(unittest.TestCase):
         )
 
         self.assertAlmostEqual(
-            LifecycleExample.solution[5].cFunc(3).tolist(), 2.129983771775666
+            LifecycleExample.solution[5].cFunc(3).tolist(), 2.12998377
         )
 
 
@@ -201,5 +200,5 @@ class testIndShockConsumerTypeFastCyclical(unittest.TestCase):
         CyclicalExample.solve()
 
         self.assertAlmostEqual(
-            CyclicalExample.solution[3].cFunc(3).tolist(), 1.5958390056965004
+            CyclicalExample.solution[3].cFunc(3).tolist(), 1.59583901
         )

--- a/HARK/tests/test_distribution.py
+++ b/HARK/tests/test_distribution.py
@@ -1,8 +1,8 @@
-import numpy as np
 import unittest
 
-import HARK.distribution as distribution
+import numpy as np
 
+import HARK.distribution as distribution
 from HARK.distribution import (
     Bernoulli,
     IndexDistribution,
@@ -14,7 +14,7 @@ from HARK.distribution import (
     Uniform,
     Weibull,
     calc_expectation,
-    combine_indep_dstns
+    combine_indep_dstns,
 )
 
 
@@ -26,7 +26,8 @@ class DiscreteDistributionTests(unittest.TestCase):
 
     def test_draw(self):
         self.assertEqual(
-            DiscreteDistribution(np.ones(1), np.zeros(1)).draw(1)[0], 0,
+            DiscreteDistribution(np.ones(1), np.zeros(1)).draw(1)[0],
+            0,
         )
 
     def test_calc_expectation(self):
@@ -42,32 +43,20 @@ class DiscreteDistributionTests(unittest.TestCase):
         self.assertAlmostEqual(ce2, 1.0)
         self.assertAlmostEqual(ce3, 10.0)
 
-        ce4= calc_expectation(
-            dd_0_1_20,
-            lambda x: 2 ** x
-        )
+        ce4 = calc_expectation(dd_0_1_20, lambda x: 2 ** x)
 
         self.assertAlmostEqual(ce4, 1.27153712)
 
-        ce5 = calc_expectation(
-            dd_1_1_40,
-            lambda x: 2 * x
-        )
+        ce5 = calc_expectation(dd_1_1_40, lambda x: 2 * x)
 
         self.assertAlmostEqual(ce5, 2.0)
 
-        ce6 = calc_expectation(
-            dd_10_10_100,
-            lambda x, y: 2 * x + y,
-            20
-        )
+        ce6 = calc_expectation(dd_10_10_100, lambda x, y: 2 * x + y, 20)
 
         self.assertAlmostEqual(ce6, 40.0)
 
         ce7 = calc_expectation(
-            dd_0_1_20,
-            lambda x, y: x + y,
-            np.hstack(np.array([0,1,2,3,4,5]))
+            dd_0_1_20, lambda x, y: x + y, np.hstack(np.array([0, 1, 2, 3, 4, 5]))
         )
 
         self.assertAlmostEqual(ce7.flat[3], 3.0)
@@ -76,10 +65,7 @@ class DiscreteDistributionTests(unittest.TestCase):
         TranShkDstn = MeanOneLogNormal().approx(200)
         IncShkDstn = combine_indep_dstns(PermShkDstn, TranShkDstn)
 
-        ce8 = calc_expectation(
-            IncShkDstn,
-            lambda X: X[0] + X[1]
-        )
+        ce8 = calc_expectation(IncShkDstn, lambda X: X[0] + X[1])
 
         self.assertAlmostEqual(ce8, 2.0)
 
@@ -90,7 +76,7 @@ class DiscreteDistributionTests(unittest.TestCase):
             1.05,  # an interest rate?
         )
 
-        self.assertAlmostEqual(ce9[3], 9.518015322143837)
+        self.assertAlmostEqual(ce9[3], 9.51801532)
 
 
 class DistributionClassTests(unittest.TestCase):
@@ -100,28 +86,27 @@ class DistributionClassTests(unittest.TestCase):
     """
 
     def test_drawMeanOneLognormal(self):
-        self.assertEqual(MeanOneLogNormal().draw(1)[0], 3.5397367004222002)
+        self.assertAlmostEqual(MeanOneLogNormal().draw(1)[0], 3.53973670)
 
     def test_Lognormal(self):
-
         dist = Lognormal()
 
-        self.assertEqual(dist.draw(1)[0], 5.836039190663969)
+        self.assertAlmostEqual(dist.draw(1)[0], 5.83603919)
 
         dist.draw(100)
         dist.reset()
 
-        self.assertEqual(dist.draw(1)[0], 5.836039190663969)
+        self.assertAlmostEqual(dist.draw(1)[0], 5.83603919)
 
     def test_Normal(self):
         dist = Normal()
 
-        self.assertEqual(dist.draw(1)[0], 1.764052345967664)
+        self.assertAlmostEqual(dist.draw(1)[0][0], 1.76405235)
 
         dist.draw(100)
         dist.reset()
 
-        self.assertEqual(dist.draw(1)[0], 1.764052345967664)
+        self.assertAlmostEqual(dist.draw(1)[0][0], 1.76405235)
 
     def test_MVNormal(self):
         dist = MVNormal()
@@ -138,20 +123,18 @@ class DistributionClassTests(unittest.TestCase):
         )
 
     def test_Weibull(self):
-        self.assertEqual(Weibull().draw(1)[0], 0.79587450816311)
+        self.assertAlmostEqual(Weibull().draw(1)[0], 0.79587451)
 
     def test_Uniform(self):
         uni = Uniform()
 
-        self.assertEqual(Uniform().draw(1)[0], 0.5488135039273248)
+        self.assertAlmostEqual(Uniform().draw(1)[0], 0.54881350)
 
-        self.assertEqual(
-            calc_expectation(uni.approx(10)),
-            0.5
-        )
+        self.assertEqual(calc_expectation(uni.approx(10)), 0.5)
 
     def test_Bernoulli(self):
         self.assertEqual(Bernoulli().draw(1)[0], False)
+
 
 class IndexDistributionClassTests(unittest.TestCase):
     """
@@ -160,23 +143,19 @@ class IndexDistributionClassTests(unittest.TestCase):
     """
 
     def test_IndexDistribution(self):
-        cd = IndexDistribution(Bernoulli, {'p' : [.01, .5, .99]})
+        cd = IndexDistribution(Bernoulli, {"p": [0.01, 0.5, 0.99]})
 
-        conditions = np.array([0,0,0,0,1,1,1,1,1,1,1,1,2,2,2,2])
+        conditions = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2])
 
         draws = cd.draw(conditions)
 
         self.assertEqual(draws[:4].sum(), 0)
-        self.assertEqual(draws[-4:].sum(),4)
-        self.assertEqual(cd[2].p.tolist(), .99)
+        self.assertEqual(draws[-4:].sum(), 4)
+        self.assertEqual(cd[2].p.tolist(), 0.99)
 
     def test_IndexDistribution_approx(self):
         cd = IndexDistribution(
-            Lognormal,
-            {
-                'mu' : [.01, .5, .99],
-                'sigma' : [.05, .05, .05]
-            }
+            Lognormal, {"mu": [0.01, 0.5, 0.99], "sigma": [0.05, 0.05, 0.05]}
         )
 
         approx = cd.approx(10)
@@ -186,18 +165,13 @@ class IndexDistributionClassTests(unittest.TestCase):
         self.assertAlmostEqual(draw[1], 2.93868620)
 
     def test_IndexDistribution_seeds(self):
-        cd = IndexDistribution(
-            Lognormal,
-            {
-                'mu' : [1, 1],
-                'sigma' : [1, 1]
-            }
-        )
+        cd = IndexDistribution(Lognormal, {"mu": [1, 1], "sigma": [1, 1]})
 
         draw_0 = cd[0].draw(1).tolist()
         draw_1 = cd[1].draw(1).tolist()
 
         self.assertNotEqual(draw_0, draw_1)
+
 
 class MarkovProcessTests(unittest.TestCase):
     """
@@ -205,7 +179,6 @@ class MarkovProcessTests(unittest.TestCase):
     """
 
     def test_draw(self):
-
         mrkv_array = np.array([[0.75, 0.25], [0.1, 0.9]])
 
         mp = distribution.MarkovProcess(mrkv_array)


### PR DESCRIPTION
This PR is a test to see if rounding numbers to 8 decimal places (assertAlmostEqual defaults to 7) fixes issues reported in #1009 

I used the following code to round all numbers with many decimal places. 

```
import re
simpledec = re.compile(r"\d*\.\d{8,20}")
def mround(match):
    return "{:.8f}".format(float(match.group()))
def round_in_file(filename):
    with open(filename, "r+") as file:
        filetext = file.read()
        filetext = re.sub(simpledec, mround, filetext)
        file.seek(0)    
        file.write(filetext)
        file.truncate() 
```