### PR TITLE
[WIP] Use calc_expectation in ConsPortfolioModel

### DIFF
--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -572,9 +572,10 @@ def solveConsPortfolio(
             return (shocks[0] * PermGroFac) ** (1.0 - CRRA) * v_next
 
         # Calculate intermediate marginal value of bank balances by taking expectations over income shocks
-        dvdb_intermed = calc_expectation(
-            IncShkDstn, dvdb_dist, bNrm_tiled, Share_tiled
-        )[:, :, 0]
+        dvdb_intermed = calc_expectation(IncShkDstn, dvdb_dist, bNrm_tiled, Share_tiled)
+        # calc_expectation returns one additional "empty" dimension, remove it
+        # this line can be deleted when calc_expectation is fixed
+        dvdb_intermed = dvdb_intermed[:, :, 0]
         dvdbNvrs_intermed = uPinv(dvdb_intermed)
         dvdbNvrsFunc_intermed = BilinearInterp(dvdbNvrs_intermed, bNrmGrid, ShareGrid)
         dvdbFunc_intermed = MargValueFuncCRRA(dvdbNvrsFunc_intermed, CRRA)
@@ -583,15 +584,19 @@ def solveConsPortfolio(
         if vFuncBool:
             v_intermed = calc_expectation(
                 IncShkDstn, v_intermed_dist, bNrm_tiled, Share_tiled
-            )[:, :, 0]
+            )
+            # calc_expectation returns one additional "empty" dimension, remove it
+            # this line can be deleted when calc_expectation is fixed
+            v_intermed = v_intermed[:, :, 0]
             vNvrs_intermed = n(v_intermed)
             vNvrsFunc_intermed = BilinearInterp(vNvrs_intermed, bNrmGrid, ShareGrid)
             vFunc_intermed = ValueFuncCRRA(vNvrsFunc_intermed, CRRA)
 
         # Calculate intermediate marginal value of risky portfolio share by taking expectations
-        dvds_intermed = calc_expectation(
-            IncShkDstn, dvds_dist, bNrm_tiled, Share_tiled
-        )[:, :, 0]
+        dvds_intermed = calc_expectation(IncShkDstn, dvds_dist, bNrm_tiled, Share_tiled)
+        # calc_expectation returns one additional "empty" dimension, remove it
+        # this line can be deleted when calc_expectation is fixed
+        dvds_intermed = dvds_intermed[:, :, 0]
         dvdsFunc_intermed = BilinearInterp(dvds_intermed, bNrmGrid, ShareGrid)
 
         # Make tiled arrays to calculate future realizations of bNrm and Share when integrating over RiskyDstn
@@ -629,10 +634,11 @@ def solveConsPortfolio(
         EndOfPrddvda = (
             DiscFac
             * LivPrb
-            * calc_expectation(RiskyDstn, EndOfPrddvda_dist, aNrm_tiled, Share_tiled)[
-                :, :, 0
-            ]
+            * calc_expectation(RiskyDstn, EndOfPrddvda_dist, aNrm_tiled, Share_tiled)
         )
+        # calc_expectation returns one additional "empty" dimension, remove it
+        # this line can be deleted when calc_expectation is fixed
+        EndOfPrddvda = EndOfPrddvda[:, :, 0]
         EndOfPrddvdaNvrs = uPinv(EndOfPrddvda)
 
         # Calculate end-of-period value by taking expectations
@@ -640,20 +646,22 @@ def solveConsPortfolio(
             EndOfPrdv = (
                 DiscFac
                 * LivPrb
-                * calc_expectation(RiskyDstn, EndOfPrdv_dist, aNrm_tiled, Share_tiled)[
-                    :, :, 0
-                ]
+                * calc_expectation(RiskyDstn, EndOfPrdv_dist, aNrm_tiled, Share_tiled)
             )
+            # calc_expectation returns one additional "empty" dimension, remove it
+            # this line can be deleted when calc_expectation is fixed
+            EndOfPrdv = EndOfPrdv[:, :, 0]
             EndOfPrdvNvrs = n(EndOfPrdv)
 
         # Calculate end-of-period marginal value of risky portfolio share by taking expectations
         EndOfPrddvds = (
             DiscFac
             * LivPrb
-            * calc_expectation(RiskyDstn, EndOfPrddvds_dist, aNrm_tiled, Share_tiled)[
-                :, :, 0
-            ]
+            * calc_expectation(RiskyDstn, EndOfPrddvds_dist, aNrm_tiled, Share_tiled)
         )
+        # calc_expectation returns one additional "empty" dimension, remove it
+        # this line can be deleted when calc_expectation is fixed
+        EndOfPrddvds = EndOfPrddvds[:, :, 0]
 
     else:  # If the distributions are NOT independent...
         # Unpack the shock distribution

--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -533,14 +533,14 @@ def solveConsPortfolio(
             return b_nrm / (PermGroFac * shocks[0]) + shocks[1]
 
         # Evaluate realizations of marginal value of market resources next period
-        def dvdm_next(shocks, b_nrm, s_next):
+        def dvdm_next(shocks, b_nrm, shares):
             mNrm = m_nrm_next(shocks, b_nrm)
             mNrm_tiled = np.tile(np.reshape(mNrm, (bNrm_N, 1)), (1, Share_N))
-            s_next_tiled = np.tile(np.reshape(s_next, (1, Share_N)), (bNrm_N, 1))
+            Share_tiled = np.tile(np.reshape(shares, (1, Share_N)), (bNrm_N, 1))
 
             dvdmAdj_next = vPfuncAdj_next(mNrm_tiled)
             if AdjustPrb < 1.0:
-                dvdmFxd_next = dvdmFuncFxd_next(mNrm_tiled, s_next_tiled)
+                dvdmFxd_next = dvdmFuncFxd_next(mNrm_tiled, Share_tiled)
                 # Combine by adjustment probability
                 dvdm = AdjustPrb * dvdmAdj_next + (1.0 - AdjustPrb) * dvdmFxd_next
             else:  # Don't bother evaluating if there's no chance that portfolio share is fixed
@@ -549,14 +549,14 @@ def solveConsPortfolio(
             return shocks[0] ** (-CRRA) * dvdm
 
         # Evaluate realizations of marginal value of risky share next period
-        def dvds_next(shocks, b_nrm, s_next):
+        def dvds_next(shocks, b_nrm, shares):
             mNrm = m_nrm_next(shocks, b_nrm)
             mNrm_tiled = np.tile(np.reshape(mNrm, (bNrm_N, 1)), (1, Share_N))
-            s_next_tiled = np.tile(np.reshape(s_next, (1, Share_N)), (bNrm_N, 1))
+            Share_tiled = np.tile(np.reshape(shares, (1, Share_N)), (bNrm_N, 1))
             # No marginal value of Share if it's a free choice!
             dvdsAdj_next = np.zeros_like(mNrm_tiled)
             if AdjustPrb < 1.0:
-                dvdsFxd_next = dvdsFuncFxd_next(mNrm_tiled, s_next_tiled)
+                dvdsFxd_next = dvdsFuncFxd_next(mNrm_tiled, Share_tiled)
                 # Combine by adjustment probability
                 dvds = AdjustPrb * dvdsAdj_next + (1.0 - AdjustPrb) * dvdsFxd_next
             else:  # Don't bother evaluating if there's no chance that portfolio share is fixed
@@ -565,14 +565,14 @@ def solveConsPortfolio(
             return shocks[0] ** (-CRRA) * dvds
 
         # If the value function has been requested, evaluate realizations of value
-        def v_next(shocks, b_nrm, s_next):
+        def v_next(shocks, b_nrm, shares):
             mNrm = m_nrm_next(shocks, b_nrm)
             mNrm_tiled = np.tile(np.reshape(mNrm, (bNrm_N, 1)), (1, Share_N))
-            s_next_tiled = np.tile(np.reshape(s_next, (1, Share_N)), (bNrm_N, 1))
+            Share_tiled = np.tile(np.reshape(shares, (1, Share_N)), (bNrm_N, 1))
 
             vAdj_next = vFuncAdj_next(mNrm_tiled)
             if AdjustPrb < 1.0:
-                vFxd_next = vFuncFxd_next(mNrm_tiled, s_next_tiled)
+                vFxd_next = vFuncFxd_next(mNrm_tiled, Share_tiled)
                 # Combine by adjustment probability
                 EndOfPrdv = AdjustPrb * vAdj_next + (1.0 - AdjustPrb) * vFxd_next
             else:  # Don't bother evaluating if there's no chance that portfolio share is fixed
@@ -608,40 +608,40 @@ def solveConsPortfolio(
 
         # Evaluate realizations of value and marginal value after asset returns are realized
 
-        def dvdb_next(shock, a_nrm, s_next):
-            a_nrm_tiled = np.tile(np.reshape(a_nrm, (aNrm_N, 1)), (1, Share_N))
-            s_next_tiled = np.tile(np.reshape(s_next, (1, Share_N)), (aNrm_N, 1))
+        def dvdb_next(shock, a_nrm, shares):
+            aNrm_tiled = np.tile(np.reshape(a_nrm, (aNrm_N, 1)), (1, Share_N))
+            Share_tiled = np.tile(np.reshape(shares, (1, Share_N)), (aNrm_N, 1))
 
             # Calculate future realizations of bank balances bNrm
             Rxs = shock - Rfree
-            Rport = Rfree + s_next_tiled * Rxs
-            b_nrm_next = Rport * a_nrm_tiled
+            Rport = Rfree + Share_tiled * Rxs
+            b_nrm_next = Rport * aNrm_tiled
 
-            return Rport * dvdbFunc_intermed(b_nrm_next, s_next_tiled)
+            return Rport * dvdbFunc_intermed(b_nrm_next, Share_tiled)
 
-        def v_next(shock, a_nrm, s_next):
-            a_nrm_tiled = np.tile(np.reshape(a_nrm, (aNrm_N, 1)), (1, Share_N))
-            s_next_tiled = np.tile(np.reshape(s_next, (1, Share_N)), (aNrm_N, 1))
-
-            # Calculate future realizations of bank balances bNrm
-            Rxs = shock - Rfree
-            Rport = Rfree + s_next_tiled * Rxs
-            b_nrm_next = Rport * a_nrm_tiled
-
-            return vFunc_intermed(b_nrm_next, s_next_tiled)
-
-        def dvds_next(shock, a_nrm, s_next):
-            a_nrm_tiled = np.tile(np.reshape(a_nrm, (aNrm_N, 1)), (1, Share_N))
-            s_next_tiled = np.tile(np.reshape(s_next, (1, Share_N)), (aNrm_N, 1))
+        def v_next(shock, a_nrm, shares):
+            aNrm_tiled = np.tile(np.reshape(a_nrm, (aNrm_N, 1)), (1, Share_N))
+            Share_tiled = np.tile(np.reshape(shares, (1, Share_N)), (aNrm_N, 1))
 
             # Calculate future realizations of bank balances bNrm
             Rxs = shock - Rfree
-            Rport = Rfree + s_next_tiled * Rxs
-            b_nrm_next = Rport * a_nrm_tiled
+            Rport = Rfree + Share_tiled * Rxs
+            b_nrm_next = Rport * aNrm_tiled
 
-            return Rxs * a_nrm_tiled * dvdbFunc_intermed(
-                b_nrm_next, s_next_tiled
-            ) + dvdsFunc_intermed(b_nrm_next, s_next_tiled)
+            return vFunc_intermed(b_nrm_next, Share_tiled)
+
+        def dvds_next(shock, a_nrm, shares):
+            aNrm_tiled = np.tile(np.reshape(a_nrm, (aNrm_N, 1)), (1, Share_N))
+            Share_tiled = np.tile(np.reshape(shares, (1, Share_N)), (aNrm_N, 1))
+
+            # Calculate future realizations of bank balances bNrm
+            Rxs = shock - Rfree
+            Rport = Rfree + Share_tiled * Rxs
+            b_nrm_next = Rport * aNrm_tiled
+
+            return Rxs * aNrm_tiled * dvdbFunc_intermed(
+                b_nrm_next, Share_tiled
+            ) + dvdsFunc_intermed(b_nrm_next, Share_tiled)
 
         # Calculate end-of-period marginal value of assets by taking expectations
         EndOfPrddvda = (

--- a/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
@@ -1,6 +1,8 @@
-import HARK.ConsumptionSaving.ConsPortfolioModel as cpm
-import numpy as np
 import unittest
+
+import numpy as np
+
+import HARK.ConsumptionSaving.ConsPortfolioModel as cpm
 
 
 class PortfolioConsumerTypeTestCase(unittest.TestCase):
@@ -13,10 +15,9 @@ class PortfolioConsumerTypeTestCase(unittest.TestCase):
 
         self.pcct.solve()
 
+
 class UnitsPortfolioConsumerTypeTestCase(PortfolioConsumerTypeTestCase):
-
     def test_RiskyShareFunc(self):
-
         self.assertAlmostEqual(
             self.pcct.solution[0].ShareFuncAdj(8).tolist(), 0.9507419932531964
         )
@@ -26,118 +27,90 @@ class UnitsPortfolioConsumerTypeTestCase(PortfolioConsumerTypeTestCase):
         )
 
     def test_solution(self):
-
         self.assertAlmostEqual(
-            self.pcct.solution[0].cFuncAdj(10).tolist(),
-            1.6996557721625785
+            self.pcct.solution[0].cFuncAdj(10).tolist(), 1.6996557721625785
         )
 
         self.assertAlmostEqual(
-            self.pcct.solution[0].ShareFuncAdj(10).tolist(),
-            0.8498496999408691
+            self.pcct.solution[0].ShareFuncAdj(10).tolist(), 0.8498496999408691
         )
 
     def test_sim_one_period(self):
-
         self.pcct.T_sim = 30
         self.pcct.AgentCount = 10
-        self.pcct.track_vars += ['aNrm']
+        self.pcct.track_vars += ["aNrm"]
         self.pcct.initialize_sim()
 
-        self.assertFalse(
-            np.any(self.pcct.shocks['Adjust'])
-        )
+        self.assertFalse(np.any(self.pcct.shocks["Adjust"]))
 
         self.pcct.sim_one_period()
 
-        self.assertAlmostEqual(
-            self.pcct.controls["Share"][0],
-            0.8627164488246847
-        )
-        self.assertAlmostEqual(
-            self.pcct.controls['cNrm'][0],
-            1.67874799
-        )
+        self.assertAlmostEqual(self.pcct.controls["Share"][0], 0.8627164488246847)
+        self.assertAlmostEqual(self.pcct.controls["cNrm"][0], 1.67874799)
+
 
 class SimulatePortfolioConsumerTypeTestCase(PortfolioConsumerTypeTestCase):
-
     def test_simulation(self):
-
         self.pcct.T_sim = 30
         self.pcct.AgentCount = 10
         self.pcct.track_vars += [
-            'mNrm',
-            'cNrm',
-            'Share',
-           'aNrm',
-            'Risky',
-            'Rport',
-            'Adjust',
-            'PermShk',
-            'bNrm'
+            "mNrm",
+            "cNrm",
+            "Share",
+            "aNrm",
+            "Risky",
+            "Rport",
+            "Adjust",
+            "PermShk",
+            "bNrm",
         ]
         self.pcct.initialize_sim()
 
         self.pcct.simulate()
 
-        self.assertAlmostEqual(
-            self.pcct.history['mNrm'][0][0], 9.70233892
-        )
+        self.assertAlmostEqual(self.pcct.history["mNrm"][0][0], 9.70233892)
 
-        self.assertAlmostEqual(
-            self.pcct.history['cNrm'][0][0], 1.6787479894848298
-        )
+        self.assertAlmostEqual(self.pcct.history["cNrm"][0][0], 1.6787479894848298)
 
-        self.assertAlmostEqual(
-            self.pcct.history['Share'][0][0], 0.8627164488246847
-        )
+        self.assertAlmostEqual(self.pcct.history["Share"][0][0], 0.8627164488246847)
 
-        self.assertAlmostEqual(
-            self.pcct.history['aNrm'][0][0], 8.023590930905383
-        )
+        self.assertAlmostEqual(self.pcct.history["aNrm"][0][0], 8.023590930905383)
 
-        self.assertAlmostEqual(
-            self.pcct.history['Adjust'][0][0], 1.0
-        )
-
+        self.assertAlmostEqual(self.pcct.history["Adjust"][0][0], 1.0)
 
         # the next period
-        self.assertAlmostEqual(
-            self.pcct.history['Risky'][1][0], 0.8950304697526602
-        )
+        self.assertAlmostEqual(self.pcct.history["Risky"][1][0], 0.8950304697526602)
 
-        self.assertAlmostEqual(
-            self.pcct.history['Rport'][1][0], 0.9135595661654792
-        )
+        self.assertAlmostEqual(self.pcct.history["Rport"][1][0], 0.9135595661654792)
 
-        self.assertAlmostEqual(
-            self.pcct.history['Adjust'][1][0], 1.0
-        )
+        self.assertAlmostEqual(self.pcct.history["Adjust"][1][0], 1.0)
 
-        self.assertAlmostEqual(
-            self.pcct.history['PermShk'][1][0], 1.0050166461586711
-        )
+        self.assertAlmostEqual(self.pcct.history["PermShk"][1][0], 1.0050166461586711)
 
-        self.assertAlmostEqual(
-            self.pcct.history['bNrm'][1][0], 7.293439643953855
-        )
+        self.assertAlmostEqual(self.pcct.history["bNrm"][1][0], 7.293439643953855)
 
-        self.assertAlmostEqual(
-            self.pcct.history['mNrm'][1][0], 8.287859049575047
-        )
+        self.assertAlmostEqual(self.pcct.history["mNrm"][1][0], 8.287859049575047)
 
-        self.assertAlmostEqual(
-            self.pcct.history['cNrm'][1][0], 1.5773607434989751
-        )
+        self.assertAlmostEqual(self.pcct.history["cNrm"][1][0], 1.5773607434989751)
 
-        self.assertAlmostEqual(
-            self.pcct.history['Share'][1][0], 0.9337608822146805
-        )
+        self.assertAlmostEqual(self.pcct.history["Share"][1][0], 0.9337608822146805)
 
-        self.assertAlmostEqual(
-            self.pcct.history['aNrm'][1][0], 6.710498306076072
-        )
+        self.assertAlmostEqual(self.pcct.history["aNrm"][1][0], 6.710498306076072)
 
-        self.assertAlmostEqual(
-            self.pcct.history['aNrm'][15][0], 5.304746367434934
-        )
+        self.assertAlmostEqual(self.pcct.history["aNrm"][15][0], 5.304746367434934)
+
+
+class testPortfolioConsumerTypeSticky(unittest.TestCase):
+    def test_sticky(self):
+        # Make another example type, but this one can only update their risky portfolio
+        # share in any particular period with 15% probability.
+        init_sticky_share = cpm.init_portfolio.copy()
+        init_sticky_share["AdjustPrb"] = 0.15
+
+        # Create portfolio choice consumer type
+        self.sticky = cpm.PortfolioConsumerType(**init_sticky_share)
+        self.sticky.cycles = 0
+
+        # Solve the model under the given parameters
+
+        self.sticky.solve()


### PR DESCRIPTION
Using `calc_expectation` improves solution speed. `test_ConsPortfolioModel.py` runtime:
- w/o `calc_expectation`: 50.05s
- w `calc_expectation`: 27.89s

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.