### PR TITLE
Distribute_params now uses assign_parameters

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -26,6 +26,8 @@ PR: [#832](https://github.com/econ-ark/HARK/pull/832). See [this forthcoming REM
 * Fix bug in DCEGM's primary kink finder due to numpy no longer accepting NaN in integer arrays [#990](https://github.com/econ-ark/HARK/pull/990).
 * Add a general class for consumers who can save using a risky asset [#1012](https://github.com/econ-ark/HARK/pull/1012/).
 Add Boolean attribute 'PerfMITShk' to consumption models. When true, allows perfect foresight MIT shocks to be simulated. [#1013](https://github.com/econ-ark/HARK/pull/1013).
+* distribute_params now uses assign_params to create consistent output
+
 ### 0.11.0
 
 Release Data: March 4, 2021

--- a/HARK/core.py
+++ b/HARK/core.py
@@ -1445,6 +1445,10 @@ def distribute_params(agent, param_name, param_count, distribution):
 
     for j in range(param_count):
         agent_set[j].AgentCount = int(agent.AgentCount * param_dist.pmf[j])
-        agent_set[j].__dict__[param_name] = param_dist.X[j]
+        # agent_set[j].__dict__[param_name] = param_dist.X[j]
+
+        agent_set[j].assign_parameters(**{param_name: param_dist.X[j]})
+
+
 
     return agent_set

--- a/HARK/tests/test_core.py
+++ b/HARK/tests/test_core.py
@@ -1,7 +1,8 @@
 """
 This file implements unit tests for interpolation methods
 """
-from HARK.core import Model, MetricObject, distance_metric, AgentType
+from HARK.core import Model, MetricObject, distance_metric, AgentType, distribute_params
+from HARK.distribution import Uniform
 
 import numpy as np
 import unittest
@@ -101,3 +102,18 @@ class test_AgentType(unittest.TestCase):
 
         self.assertEqual(self.agent, agent2)
         self.assertNotEqual(self.agent, agent3)
+
+class test_distribute_params(unittest.TestCase):
+    def setUp(self):
+        self.agent = AgentType(cycles=1, AgentCount=3)
+
+
+    def test_distribute_params(self):
+        dist = Uniform(bot=0.9, top=0.94)
+
+        self.agents = distribute_params(self.agent, 'DiscFac', 3, dist)
+
+        self.assertTrue(all(['DiscFac' in agent.parameters for agent in self.agents]))
+        self.assertTrue(all([self.agents[i].parameters['DiscFac'] == dist.approx(3).X[i] for i in range(3)]))
+
+


### PR DESCRIPTION
Addresses #994 by making distribute_params use assign_parameters. This ensures that the output of an AgentType matches the real parameter values. Before, if parameters were changed with distribute_params the output would not reflect the changes even though the underlying attribute would be changed. 

<!--- Put an `x` in all the boxes that apply: -->
- [x ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x ] Updated documentation of features that add new functionality.
- [ x] Update CHANGELOG.md with major/minor changes.
