### PR TITLE
Track and update start-of-period assets as states in RiskyContrib

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -26,6 +26,7 @@ PR: [#832](https://github.com/econ-ark/HARK/pull/832). See [this forthcoming REM
 * Fix bug in DCEGM's primary kink finder due to numpy no longer accepting NaN in integer arrays [#990](https://github.com/econ-ark/HARK/pull/990).
 * Add a general class for consumers who can save using a risky asset [#1012](https://github.com/econ-ark/HARK/pull/1012/).
 Add Boolean attribute 'PerfMITShk' to consumption models. When true, allows perfect foresight MIT shocks to be simulated. [#1013](https://github.com/econ-ark/HARK/pull/1013).
+* Track and update start-of-period (pre-income) risky and risk-free assets as states in the `RiskyContrib` model [1046](https://github.com/econ-ark/HARK/pull/1046).
 ### 0.11.0
 
 Release Data: March 4, 2021

--- a/HARK/ConsumptionSaving/ConsRiskyContribModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyContribModel.py
@@ -65,6 +65,7 @@ class RiskyContribConsumerType(RiskyAssetConsumerType):
     # For details, see
     # https://github.com/Mv77/RiskyContrib/blob/main/RiskyContrib.pdf
     state_vars = RiskyAssetConsumerType.state_vars + [
+        "gNrm",
         "nNrm",
         "mNrmTilde",
         "nNrmTilde",
@@ -427,13 +428,13 @@ class RiskyContribConsumerType(RiskyAssetConsumerType):
         RfEff = Rfree / self.shocks["PermShk"]
         RrEff = Rrisk / self.shocks["PermShk"]
 
-        bNrm = RfEff * aNrmPrev  # Liquid balances before labor income
-        gNrm = RrEff * nNrmTildePrev  # Iliquid balances before labor income
+        self.state_now["bNrm"] = RfEff * aNrmPrev  # Liquid balances before labor income
+        self.state_now["gNrm"] = RrEff * nNrmTildePrev  # Iliquid balances before labor income
 
         # Liquid balances after labor income
-        self.state_now["mNrm"] = bNrm + self.shocks["TranShk"] * (1 - SharePrev)
+        self.state_now["mNrm"] = self.state_now["bNrm"] + self.shocks["TranShk"] * (1 - SharePrev)
         # Iliquid balances after labor income
-        self.state_now["nNrm"] = gNrm + self.shocks["TranShk"] * SharePrev
+        self.state_now["nNrm"] = self.state_now["gNrm"] + self.shocks["TranShk"] * SharePrev
 
         return None
 


### PR DESCRIPTION
My new model did not keep track and properly update start-of-period assets (both risky and risk-free). This PR makes them proper states that get updates throughout simulations.

These entities are not needed to solve the model, but some users might want to record them in simulations and this change makes it easier to do so. 

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
