### PR TITLE
Use .fill(np.nan) when clearing simulation histories

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -32,6 +32,7 @@ Add Boolean attribute 'PerfMITShk' to consumption models. When true, allows perf
 * Track and update start-of-period (pre-income) risky and risk-free assets as states in the `RiskyContrib` model [1046](https://github.com/econ-ark/HARK/pull/1046).
 * distribute_params now uses assign_params to create consistent output [#1044](https://github.com/econ-ark/HARK/pull/1044)
 * The function that computes end-of-period derivatives of the value function was moved to the inside of `ConsRiskyContrib`'s solver [#1057](https://github.com/econ-ark/HARK/pull/1057)
+* Use `np.fill(np.nan)` to clear or initialize the arrays that store simulations. [#1068](https://github.com/econ-ark/HARK/pull/1068)
 
 ### 0.11.0
 

--- a/HARK/core.py
+++ b/HARK/core.py
@@ -863,7 +863,8 @@ class AgentType(Model):
         None
         """
         for var_name in self.track_vars:
-            self.history[var_name] = np.empty((self.T_sim, self.AgentCount)) + np.nan
+            self.history[var_name] = np.empty((self.T_sim, self.AgentCount))
+            self.history[var_name].fill(np.nan)
 
 
 class Frame():


### PR DESCRIPTION
The line that clears the tracked variables in simulations,
`self.history[var_name] = np.empty((self.T_sim, self.AgentCount)) + np.nan` 
is sometimes producing an annoying warning
`RuntimeWarning: invalid value encountered in add`
The warning is also being printed and not logged and I'm not sure why.

In any case, it seems like a more "pythonic" way to clear/initialize the arrays and one that eliminates the warning is using `np.fill`. That's what this PR does.