### PR TITLE
Fix transformations between normal and lognormal parameters

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -40,6 +40,7 @@ PR: [#832](https://github.com/econ-ark/HARK/pull/832). See [this forthcoming REM
 * Add Boolean attribute 'neutral_measure' to consumption models. When true, simulations are more precise by allowing permanent shocks to be drawn from a neutral measure (see Harmenberg 2021). [#1069](https://github.com/econ-ark/HARK/pull/1069)
 * Fix mathematical limits of model example in `example_ConsPortfolioModel.ipynb` [#1047](https://github.com/econ-ark/HARK/pull/1047)
 * Update `ConsGenIncProcessModel.py` to use `calc_expectation` method [#1072](https://github.com/econ-ark/HARK/pull/1072)
+* Fix bug in `calc_normal_style_pars_from_lognormal_pars` due to math error. [#1076](https://github.com/econ-ark/HARK/pull/1076)
 
 ### 0.11.0
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -1,10 +1,9 @@
-from HARK.utilities import memoize
-from itertools import product
 import math
+from itertools import product
+
 import numpy as np
-from scipy.special import erf, erfc
 import scipy.stats as stats
-from types import SimpleNamespace
+from scipy.special import erf, erfc
 
 
 class Distribution:
@@ -16,8 +15,8 @@ class Distribution:
     seed : int
         Seed for random number generator.
     """
-    def __init__(self, seed=0):
 
+    def __init__(self, seed=0):
         self.RNG = np.random.RandomState(seed)
         self.seed = seed
 
@@ -29,6 +28,7 @@ class Distribution:
         ----------
         """
         self.RNG = np.random.RandomState(self.seed)
+
 
 class IndexDistribution(Distribution):
     """
@@ -58,10 +58,11 @@ class IndexDistribution(Distribution):
     seed : int
         Seed for random number generator.
     """
+
     conditional = None
     engine = None
 
-    def __init__(self, engine, conditional, seed = 0):
+    def __init__(self, engine, conditional, seed=0):
         # Set up the RNG
         super().__init__(seed)
 
@@ -73,15 +74,14 @@ class IndexDistribution(Distribution):
         item0 = list(self.conditional.values())[0]
 
         if type(item0) is list:
-            cond = {key : val[y] for (key, val) in self.conditional.items()}
-            return self.engine(
-                    seed=self.RNG.randint(0, 2 ** 31 - 1),
-                    **cond
-                )
+            cond = {key: val[y] for (key, val) in self.conditional.items()}
+            return self.engine(seed=self.RNG.randint(0, 2 ** 31 - 1), **cond)
         else:
-            raise(Exception(
-                f"IndexDistribution: Unhandled case for __getitem__ access. y: {y}; conditional: {conditional}"
-                ))
+            raise (
+                Exception(
+                    f"IndexDistribution: Unhandled case for __getitem__ access. y: {y}; conditional: {self.conditional}"
+                )
+            )
 
     def approx(self, N, **kwds):
         """
@@ -115,15 +115,13 @@ class IndexDistribution(Distribution):
         if type(item0) is float:
             # degenerate case. Treat the parameterization as constant.
             return self.engine(
-                seed = self.RNG.randint(0, 2 ** 31 - 1),
-                **self.conditional
-                ).approx(N,**kwds)
+                seed=self.RNG.randint(0, 2 ** 31 - 1), **self.conditional
+            ).approx(N, **kwds)
 
         if type(item0) is list:
             return TimeVaryingDiscreteDistribution(
-                [self[i].approx(N,**kwds) for i, _ in enumerate(item0)]
+                [self[i].approx(N, **kwds) for i, _ in enumerate(item0)]
             )
-
 
     def draw(self, condition):
         """
@@ -154,9 +152,8 @@ class IndexDistribution(Distribution):
             N = condition.size
 
             return self.engine(
-                seed = self.RNG.randint(0, 2 ** 31 - 1),
-                **self.conditional
-                ).draw(N)
+                seed=self.RNG.randint(0, 2 ** 31 - 1), **self.conditional
+            ).draw(N)
 
         if type(item0) is list:
             # conditions are indices into list
@@ -169,10 +166,11 @@ class IndexDistribution(Distribution):
                 these = c == condition
                 N = np.sum(these)
 
-                cond = {key : val[c] for (key, val) in self.conditional.items()}
+                cond = {key: val[c] for (key, val) in self.conditional.items()}
                 draws[these] = self[c].draw(N)
 
             return draws
+
 
 class TimeVaryingDiscreteDistribution(Distribution):
     """
@@ -190,9 +188,10 @@ class TimeVaryingDiscreteDistribution(Distribution):
     seed : int
         Seed for random number generator.
     """
+
     distributions = []
 
-    def __init__(self, distributions, seed = 0):
+    def __init__(self, distributions, seed=0):
         # Set up the RNG
         super().__init__(seed)
 
@@ -236,6 +235,7 @@ class TimeVaryingDiscreteDistribution(Distribution):
 
         return draws
 
+
 ### CONTINUOUS DISTRIBUTIONS
 
 
@@ -265,10 +265,10 @@ class Lognormal(Distribution):
         super().__init__(seed)
 
         if self.mu.size != self.sigma.size:
-                raise Exception(
-                    "mu and sigma must be of same size, are %s, %s"
-                    % ((self.mu.size), (self.sigma.size))
-                )
+            raise Exception(
+                "mu and sigma must be of same size, are %s, %s"
+                % ((self.mu.size), (self.sigma.size))
+            )
 
     def draw(self, N):
         """
@@ -294,9 +294,7 @@ class Lognormal(Distribution):
         for j in range(self.mu.size):
             draws.append(
                 self.RNG.lognormal(
-                    mean=self.mu.item(j),
-                    sigma=self.sigma.item(j),
-                    size=N
+                    mean=self.mu.item(j), sigma=self.sigma.item(j), size=N
                 )
             )
         # TODO: change return type to np.array?
@@ -406,7 +404,7 @@ class Lognormal(Distribution):
         )
 
     @classmethod
-    def from_mean_std(cls, mean, std, seed = 0):
+    def from_mean_std(cls, mean, std, seed=0):
         """
         Construct a LogNormal distribution from its
         mean and standard deviation.
@@ -429,20 +427,21 @@ class Lognormal(Distribution):
         Returns
         ---------
         LogNormal
- 
+
         """
         mean_squared = mean ** 2
         variance = std ** 2
         mu = np.log(mean / (np.sqrt(1.0 + variance / mean_squared)))
         sigma = np.sqrt(np.log(1.0 + variance / mean_squared))
 
-        return cls(mu = mu, sigma = sigma, seed = seed)
+        return cls(mu=mu, sigma=sigma, seed=seed)
 
 
 class MeanOneLogNormal(Lognormal):
     def __init__(self, sigma=1.0, seed=0):
         mu = -0.5 * sigma ** 2
         super().__init__(mu=mu, sigma=sigma, seed=seed)
+
 
 class Normal(Distribution):
     """
@@ -505,17 +504,16 @@ class Normal(Distribution):
         return DiscreteDistribution(
             pmf, X, seed=self.RNG.randint(0, 2 ** 31 - 1, dtype="int32")
         )
-    
-    def approx_equiprobable(self, N):
 
-        CDF = np.linspace(0,1,N+1)
+    def approx_equiprobable(self, N):
+        CDF = np.linspace(0, 1, N + 1)
         lims = stats.norm.ppf(CDF)
-        scores = (lims - self.mu)/self.sigma
+        scores = (lims - self.mu) / self.sigma
         pdf = stats.norm.pdf(scores)
-        
+
         # Find conditional means using Mills's ratio
         pmf = np.diff(CDF)
-        X = self.mu - np.diff(pdf)/pmf
+        X = self.mu - np.diff(pdf) / pmf
 
         return DiscreteDistribution(
             pmf, X, seed=self.RNG.randint(0, 2 ** 31 - 1, dtype="int32")
@@ -540,7 +538,7 @@ class MVNormal(Distribution):
     mu = None
     Sigma = None
 
-    def __init__(self, mu = np.array([1,1]), Sigma = np.array([[1,0],[0,1]]), seed=0):
+    def __init__(self, mu=np.array([1, 1]), Sigma=np.array([[1, 0], [0, 1]]), seed=0):
         self.mu = mu
         self.Sigma = Sigma
         self.M = len(self.mu)
@@ -563,30 +561,30 @@ class MVNormal(Distribution):
             draws. Each row represents a draw.
         """
         draws = self.RNG.multivariate_normal(self.mu, self.Sigma, N)
-        
+
         return draws
 
-    def approx(self, N, equiprobable = False):
+    def approx(self, N, equiprobable=False):
         """
         Returns a discrete approximation of this distribution.
-        
+
         The discretization will have N**M points, where M is the dimension of
         the multivariate normal.
-        
+
         It uses the fact that:
             - Being positive definite, Sigma can be factorized as Sigma = QVQ',
               with V diagonal. So, letting A=Q*sqrt(V), Sigma = A*A'.
             - If Z is an N-dimensional multivariate standard normal, then
               A*Z ~ N(0,A*A' = Sigma).
-        
+
         The idea therefore is to construct an equiprobable grid for a standard
         normal and multiply it by matrix A.
         """
-        
+
         # Start by computing matrix A.
         v, Q = np.linalg.eig(self.Sigma)
         sqrtV = np.diag(np.sqrt(v))
-        A = np.matmul(Q,sqrtV) 
+        A = np.matmul(Q, sqrtV)
 
         # Now find a discretization for a univariate standard normal.
         if equiprobable:
@@ -595,16 +593,19 @@ class MVNormal(Distribution):
             z_approx = Normal().approx(N)
 
         # Now create the multivariate grid and pmf
-        Z = np.array(list(product(*[z_approx.X]*self.M)))
-        pmf = np.prod(np.array(list(product(*[z_approx.pmf]*self.M))),axis = 1)
-        
+        Z = np.array(list(product(*[z_approx.X] * self.M)))
+        pmf = np.prod(np.array(list(product(*[z_approx.pmf] * self.M))), axis=1)
+
         # Apply mean and standard deviation to the Z grid
-        X = np.tile(np.reshape(self.mu, (1, self.M)), (N**self.M,1)) + np.matmul(Z, A.T)
-        
+        X = np.tile(np.reshape(self.mu, (1, self.M)), (N ** self.M, 1)) + np.matmul(
+            Z, A.T
+        )
+
         # Construct and return discrete distribution
         return DiscreteDistribution(
             pmf, X, seed=self.RNG.randint(0, 2 ** 31 - 1, dtype="int32")
         )
+
 
 class Weibull(Distribution):
     """
@@ -713,8 +714,8 @@ class Uniform(Distribution):
         draws = []
         for j in range(self.bot.size):
             draws.append(
-                self.bot.item(j) + (self.top.item(j) - self.bot.item(j))
-                * self.RNG.rand(N)
+                self.bot.item(j)
+                + (self.top.item(j) - self.bot.item(j)) * self.RNG.rand(N)
             )
         return draws[0] if len(draws) == 1 else draws
 
@@ -742,6 +743,7 @@ class Uniform(Distribution):
         return DiscreteDistribution(
             pmf, X, seed=self.RNG.randint(0, 2 ** 31 - 1, dtype="int32")
         )
+
 
 ### DISCRETE DISTRIBUTIONS
 
@@ -902,6 +904,7 @@ class DiscreteDistribution(Distribution):
 
         return draws
 
+
 def approx_lognormal_gauss_hermite(N, mu=0.0, sigma=1.0, seed=0):
     d = Normal(mu, sigma).approx(N)
     return DiscreteDistribution(d.pmf, np.exp(d.X), seed=seed)
@@ -909,8 +912,8 @@ def approx_lognormal_gauss_hermite(N, mu=0.0, sigma=1.0, seed=0):
 
 def calc_normal_style_pars_from_lognormal_pars(avg_lognormal, std_lognormal):
     varLognormal = std_lognormal ** 2
-    avgNormal = math.log(avg_lognormal / math.sqrt(1 + varLognormal / avg_lognormal ** 2))
-    varNormal = math.sqrt(math.log(1 + varLognormal / avg_lognormal ** 2))
+    varNormal = math.log(1 + varLognormal / avg_lognormal ** 2)
+    avgNormal = math.log(avg_lognormal) - varNormal * 0.5
     std_normal = math.sqrt(varNormal)
     return avgNormal, std_normal
 
@@ -918,7 +921,7 @@ def calc_normal_style_pars_from_lognormal_pars(avg_lognormal, std_lognormal):
 def calc_lognormal_style_pars_from_normal_pars(mu_normal, std_normal):
     varNormal = std_normal ** 2
     avg_lognormal = math.exp(mu_normal + varNormal * 0.5)
-    varLognormal = (math.exp(varNormal) - 1) * math.exp(2 * mu_normal + varNormal)
+    varLognormal = (math.exp(varNormal) - 1) * avg_lognormal ** 2
     std_lognormal = math.sqrt(varLognormal)
     return avg_lognormal, std_lognormal
 
@@ -1152,11 +1155,13 @@ def add_discrete_outcome_constant_mean(distribution, x, p, sort=False):
         return DiscreteDistribution(pmf, X)
     elif type(distribution) == TimeVaryingDiscreteDistribution:
         # apply recursively on all the internal distributions
-        return TimeVaryingDiscreteDistribution([
-            add_discrete_outcome_constant_mean(d, x, p)
-            for d
-            in distribution.distributions
-        ], seed = distribution.seed)
+        return TimeVaryingDiscreteDistribution(
+            [
+                add_discrete_outcome_constant_mean(d, x, p)
+                for d in distribution.distributions
+            ],
+            seed=distribution.seed,
+        )
 
 
 def add_discrete_outcome(distribution, x, p, sort=False):
@@ -1237,7 +1242,7 @@ def combine_indep_dstns(*distributions, seed=0):
         )
 
         # The tiling we want to do
-        dist_tiles = dist_lengths[:dd] + (1,) + dist_lengths[dd + 1:]
+        dist_tiles = dist_lengths[:dd] + (1,) + dist_lengths[dd + 1 :]
 
         # Now we are ready to tile.
         # We don't use the np.meshgrid commands, because they do not
@@ -1269,8 +1274,9 @@ def combine_indep_dstns(*distributions, seed=0):
     assert np.isclose(np.sum(P_out), 1), "Probabilities do not sum to 1!"
     return DiscreteDistribution(P_out, X_out, seed=seed)
 
+
 def calc_expectation(dstn, func=lambda x: x, *args):
-    '''
+    """
     Expectation of a function, given an array of configurations of its inputs
     along with a DiscreteDistribution object that specifies the probability
     of each configuration.
@@ -1297,7 +1303,7 @@ def calc_expectation(dstn, func=lambda x: x, *args):
     f_exp : np.array or scalar
         The expectation of the function at the queried values.
         Scalar if only one value.
-    '''
+    """
     N = dstn.dim()
 
     dstn_array = np.column_stack(dstn.X)
@@ -1306,15 +1312,10 @@ def calc_expectation(dstn, func=lambda x: x, *args):
         # numpy is weird about 1-D arrays.
         dstn_array = dstn_array.T
 
-    f_query = np.apply_along_axis(
-        func, 0, dstn_array, *args
-    )
+    f_query = np.apply_along_axis(func, 0, dstn_array, *args)
 
     # Compute expectations over the values
-    f_exp = np.dot(
-        f_query,
-        np.vstack(dstn.pmf)
-    )
+    f_exp = np.dot(f_query, np.vstack(dstn.pmf))
 
     # a hack.
     if f_exp.size == 1:
@@ -1365,10 +1366,10 @@ class MarkovProcess(Distribution):
         new_state : int or nd.array
             New states.
         """
+
         def sample(s):
             return self.RNG.choice(
-                self.transition_matrix.shape[1],
-                p = self.transition_matrix[s,:]
+                self.transition_matrix.shape[1], p=self.transition_matrix[s, :]
             )
 
         array_sample = np.frompyfunc(sample, 1, 1)

--- a/HARK/tests/test_distribution.py
+++ b/HARK/tests/test_distribution.py
@@ -1,20 +1,22 @@
-import numpy as np
 import unittest
 
-import HARK.distribution as distribution
+import numpy as np
 
 from HARK.distribution import (
     Bernoulli,
-    IndexDistribution,
+    calc_expectation,
+    calc_lognormal_style_pars_from_normal_pars,
+    calc_normal_style_pars_from_lognormal_pars,
+    combine_indep_dstns,
     DiscreteDistribution,
+    IndexDistribution,
     Lognormal,
+    MarkovProcess,
     MeanOneLogNormal,
-    Normal,
     MVNormal,
+    Normal,
     Uniform,
     Weibull,
-    calc_expectation,
-    combine_indep_dstns
 )
 
 
@@ -26,7 +28,8 @@ class DiscreteDistributionTests(unittest.TestCase):
 
     def test_draw(self):
         self.assertEqual(
-            DiscreteDistribution(np.ones(1), np.zeros(1)).draw(1)[0], 0,
+            DiscreteDistribution(np.ones(1), np.zeros(1)).draw(1)[0],
+            0,
         )
 
     def test_calc_expectation(self):
@@ -42,32 +45,20 @@ class DiscreteDistributionTests(unittest.TestCase):
         self.assertAlmostEqual(ce2, 1.0)
         self.assertAlmostEqual(ce3, 10.0)
 
-        ce4= calc_expectation(
-            dd_0_1_20,
-            lambda x: 2 ** x
-        )
+        ce4 = calc_expectation(dd_0_1_20, lambda x: 2 ** x)
 
         self.assertAlmostEqual(ce4, 1.27153712)
 
-        ce5 = calc_expectation(
-            dd_1_1_40,
-            lambda x: 2 * x
-        )
+        ce5 = calc_expectation(dd_1_1_40, lambda x: 2 * x)
 
         self.assertAlmostEqual(ce5, 2.0)
 
-        ce6 = calc_expectation(
-            dd_10_10_100,
-            lambda x, y: 2 * x + y,
-            20
-        )
+        ce6 = calc_expectation(dd_10_10_100, lambda x, y: 2 * x + y, 20)
 
         self.assertAlmostEqual(ce6, 40.0)
 
         ce7 = calc_expectation(
-            dd_0_1_20,
-            lambda x, y: x + y,
-            np.hstack(np.array([0,1,2,3,4,5]))
+            dd_0_1_20, lambda x, y: x + y, np.hstack(np.array([0, 1, 2, 3, 4, 5]))
         )
 
         self.assertAlmostEqual(ce7.flat[3], 3.0)
@@ -76,10 +67,7 @@ class DiscreteDistributionTests(unittest.TestCase):
         TranShkDstn = MeanOneLogNormal().approx(200)
         IncShkDstn = combine_indep_dstns(PermShkDstn, TranShkDstn)
 
-        ce8 = calc_expectation(
-            IncShkDstn,
-            lambda X: X[0] + X[1]
-        )
+        ce8 = calc_expectation(IncShkDstn, lambda X: X[0] + X[1])
 
         self.assertAlmostEqual(ce8, 2.0)
 
@@ -103,7 +91,6 @@ class DistributionClassTests(unittest.TestCase):
         self.assertEqual(MeanOneLogNormal().draw(1)[0], 3.5397367004222002)
 
     def test_Lognormal(self):
-
         dist = Lognormal()
 
         self.assertEqual(dist.draw(1)[0], 5.836039190663969)
@@ -145,13 +132,11 @@ class DistributionClassTests(unittest.TestCase):
 
         self.assertEqual(Uniform().draw(1)[0], 0.5488135039273248)
 
-        self.assertEqual(
-            calc_expectation(uni.approx(10)),
-            0.5
-        )
+        self.assertEqual(calc_expectation(uni.approx(10)), 0.5)
 
     def test_Bernoulli(self):
         self.assertEqual(Bernoulli().draw(1)[0], False)
+
 
 class IndexDistributionClassTests(unittest.TestCase):
     """
@@ -160,23 +145,19 @@ class IndexDistributionClassTests(unittest.TestCase):
     """
 
     def test_IndexDistribution(self):
-        cd = IndexDistribution(Bernoulli, {'p' : [.01, .5, .99]})
+        cd = IndexDistribution(Bernoulli, {"p": [0.01, 0.5, 0.99]})
 
-        conditions = np.array([0,0,0,0,1,1,1,1,1,1,1,1,2,2,2,2])
+        conditions = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2])
 
         draws = cd.draw(conditions)
 
         self.assertEqual(draws[:4].sum(), 0)
-        self.assertEqual(draws[-4:].sum(),4)
-        self.assertEqual(cd[2].p.tolist(), .99)
+        self.assertEqual(draws[-4:].sum(), 4)
+        self.assertEqual(cd[2].p.tolist(), 0.99)
 
     def test_IndexDistribution_approx(self):
         cd = IndexDistribution(
-            Lognormal,
-            {
-                'mu' : [.01, .5, .99],
-                'sigma' : [.05, .05, .05]
-            }
+            Lognormal, {"mu": [0.01, 0.5, 0.99], "sigma": [0.05, 0.05, 0.05]}
         )
 
         approx = cd.approx(10)
@@ -186,18 +167,13 @@ class IndexDistributionClassTests(unittest.TestCase):
         self.assertAlmostEqual(draw[1], 2.93868620)
 
     def test_IndexDistribution_seeds(self):
-        cd = IndexDistribution(
-            Lognormal,
-            {
-                'mu' : [1, 1],
-                'sigma' : [1, 1]
-            }
-        )
+        cd = IndexDistribution(Lognormal, {"mu": [1, 1], "sigma": [1, 1]})
 
         draw_0 = cd[0].draw(1).tolist()
         draw_1 = cd[1].draw(1).tolist()
 
         self.assertNotEqual(draw_0, draw_1)
+
 
 class MarkovProcessTests(unittest.TestCase):
     """
@@ -205,10 +181,9 @@ class MarkovProcessTests(unittest.TestCase):
     """
 
     def test_draw(self):
-
         mrkv_array = np.array([[0.75, 0.25], [0.1, 0.9]])
 
-        mp = distribution.MarkovProcess(mrkv_array)
+        mp = MarkovProcess(mrkv_array)
 
         new_state = mp.draw(np.zeros(100).astype(int))
 
@@ -217,3 +192,25 @@ class MarkovProcessTests(unittest.TestCase):
         new_state = mp.draw(new_state)
 
         self.assertEqual(new_state.sum(), 39)
+
+
+class LogNormalToNormalTests(unittest.TestCase):
+    """
+    Tests methods to convert between lognormal and normal parameters.
+    """
+
+    def test_lognorm_to_norm(self):
+        avg_ln, std_ln = 1.0, 0.2
+        avg_n, std_n = calc_normal_style_pars_from_lognormal_pars(avg_ln, std_ln)
+        avg_hat, std_hat = calc_lognormal_style_pars_from_normal_pars(avg_n, std_n)
+
+        self.assertAlmostEqual(avg_ln, avg_hat)
+        self.assertAlmostEqual(std_ln, std_hat)
+
+    def test_norm_to_lognorm(self):
+        avg_n, std_n = 1.0, 0.2
+        avg_ln, std_ln = calc_lognormal_style_pars_from_normal_pars(avg_n, std_n)
+        avg_hat, std_hat = calc_normal_style_pars_from_lognormal_pars(avg_ln, std_ln)
+
+        self.assertAlmostEqual(avg_n, avg_hat)
+        self.assertAlmostEqual(std_n, std_hat)


### PR DESCRIPTION
Fixes a math error in `calc_normal_style_pars_from_lognormal_pars`.

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Update CHANGELOG.md with major/minor changes.
