### PR TITLE
[WIP]: normalize_shocks and normalize_levels allow user to impose true propositions on sims

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2209,11 +2209,13 @@ class IndShockConsumerType(PerfForesightConsumerType):
                     PermShkMeanNow = np.mean(IncShks[0])
                     TranShkMeanNow = np.mean(IncShks[1])
 
-                PermShkNow[these] = (# permanent "shock" includes expected growth
-                    (IncShks[0, :] / PermShkMeanNow) * PermGroFacNow
-                )  
+                PermShkNow[these] = (
+                    (IncShks[0, :] * PermGroFacNow
+                     / PermShkMeanNow) 
+                )  # permanent "shock" includes expected growth
                 TranShkNow[these] = (
-                    (IncShks[1, :] / TranShkMeanNow) 
+                    (IncShks[1, :]
+                     / TranShkMeanNow) 
                 )
 
         # That procedure used the *last* period in the sequence for newborns, but that's not right
@@ -2221,7 +2223,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
         N = np.sum(newborn)
         if N > 0:
             these = newborn
-            IncShkDstnNow = self.IncShkDstn[0]  # set current shock distribution
+            IncShkDstnNow = self.IncShkDstn[0]  # set current income distribution
             PermGroFacNow = self.PermGroFac[0]  # and permanent growth factor
 
             # Get random draws of income shocks from the discrete distribution
@@ -2234,11 +2236,13 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 PermShkMeanNow = np.mean(IncShkDstnNow.X[0][EventDraws])
                 TranShkMeanNow = np.mean(IncShkDstnNow.X[1][EventDraws])
                     
-            PermShkNow[these] = (# permanent "shock" includes expected growth
-                (IncShkDstnNow.X[0][EventDraws] / PermShkMeanNow)* PermGroFacNow 
+            PermShkNow[these] = (
+                (IncShkDstnNow.X[0][EventDraws] * PermGroFacNow
+                 / PermShkMeanNow)
             )  
             TranShkNow[these] = (
-                (IncShkDstnNow.X[1][EventDraws] / TranShkMeanNow)
+                (IncShkDstnNow.X[1][EventDraws]
+                 / TranShkMeanNow)
             )
         #        PermShkNow[newborn] = 1.0
         TranShkNow[newborn] = 1.0
@@ -2399,7 +2403,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
         #        AgentType.pre_solve(self)
         # Update all income process variables to match any attributes that might
         # have been changed since `__init__` or `solve()` was last called.
-        self.update_income_process()
+        #        self.update_income_process()
         self.update_solution_terminal()
         if not self.quiet:
             self.check_conditions(verbose=self.verbose)

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -1800,7 +1800,7 @@ class PerfForesightConsumerType(AgentType):
         if self.normalize_levels == True:
             pLvlNowMean = np.mean(pLvlNow)
 
-        pLvlNow = pLvlNow / pLvlNowMean # Does nothing if normalize_levels != True
+        pLvlNow = pLvlNow / pLvlNowMean # Divide by 1.0 if normalize_levels=False
         
         # Updated aggregate permanent productivity level
         PlvlAggNow = self.state_prev['PlvlAgg']*self.PermShkAggNow
@@ -2211,7 +2211,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
 
                 PermShkNow[these] = (
                     (IncShks[0, :] * PermGroFacNow
-                     / PermShkMeanNow) 
+                     / PermShkMeanNow) # Divide by 1.0 if normalize_shocks=False
                 )  # permanent "shock" includes expected growth
                 TranShkNow[these] = IncShks[1, :] / TranShkMeanNow 
 
@@ -2235,7 +2235,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
                     
             PermShkNow[these] = (
                 (IncShkDstnNow.X[0][EventDraws] * PermGroFacNow
-                 / PermShkMeanNow)
+                 / PermShkMeanNow) # Divide by 1.0 if normalize_shocks=False
             )  # permanent "shock" includes expected growth
             TranShkNow[these] = IncShkDstnNow.X[1][EventDraws] / TranShkMeanNow
         #        PermShkNow[newborn] = 1.0
@@ -2763,8 +2763,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
                     
                 if not hasattr(self, "neutral_measure"):
                     self.neutral_measure = False
-
-                # Use Harmenberg (2021) permanent income neutral measure
+                    
                 if self.neutral_measure == True:
                     PermShkDstn_t.pmf = PermShkDstn_t.X*PermShkDstn_t.pmf
                 

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2761,11 +2761,11 @@ class IndShockConsumerType(PerfForesightConsumerType):
                     PermShkCount, tail_N=0
                 )
 
-                if not hasattr(self, "normalize_shocks"):
-                    self.normalize_shocks = False
+                # if not hasattr(self, "normalize_shocks"):
+                #     self.normalize_shocks = False
                     
-                if not hasattr(self, "normalize_levels"):
-                    self.normalize_levels = False
+                # if not hasattr(self, "normalize_levels"):
+                #     self.normalize_levels = False
                     
                 if not hasattr(self, "neutral_measure"):
                     self.neutral_measure = False

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2213,10 +2213,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
                     (IncShks[0, :] * PermGroFacNow
                      / PermShkMeanNow) 
                 )  # permanent "shock" includes expected growth
-                TranShkNow[these] = (
-                    (IncShks[1, :]
-                     / TranShkMeanNow) 
-                )
+                TranShkNow[these] = IncShks[1, :] / TranShkMeanNow 
 
         # That procedure used the *last* period in the sequence for newborns, but that's not right
         # Redraw shocks for newborns, using the *first* period in the sequence.  Approximation.

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2761,12 +2761,6 @@ class IndShockConsumerType(PerfForesightConsumerType):
                     PermShkCount, tail_N=0
                 )
 
-                # if not hasattr(self, "normalize_shocks"):
-                #     self.normalize_shocks = False
-                    
-                # if not hasattr(self, "normalize_levels"):
-                #     self.normalize_levels = False
-                    
                 if not hasattr(self, "neutral_measure"):
                     self.neutral_measure = False
                     

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2399,7 +2399,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
         #        AgentType.pre_solve(self)
         # Update all income process variables to match any attributes that might
         # have been changed since `__init__` or `solve()` was last called.
-        #        self.update_income_process()
+        self.update_income_process()
         self.update_solution_terminal()
         if not self.quiet:
             self.check_conditions(verbose=self.verbose)

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2236,11 +2236,8 @@ class IndShockConsumerType(PerfForesightConsumerType):
             PermShkNow[these] = (
                 (IncShkDstnNow.X[0][EventDraws] * PermGroFacNow
                  / PermShkMeanNow)
-            )  
-            TranShkNow[these] = (
-                (IncShkDstnNow.X[1][EventDraws]
-                 / TranShkMeanNow)
-            )
+            )  # permanent "shock" includes expected growth
+            TranShkNow[these] = IncShkDstnNow.X[1][EventDraws] / TranShkMeanNow
         #        PermShkNow[newborn] = 1.0
         TranShkNow[newborn] = 1.0
 

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -1797,6 +1797,12 @@ class PerfForesightConsumerType(AgentType):
         # Asymptotically it can't hurt to impose true restrictions
         # (at least if the GICRaw holds)
         pLvlNowMean = 1.0
+        if not hasattr(self, "normalize_shocks"):
+            self.normalize_shocks = False
+            
+        if not hasattr(self, "normalize_levels"):
+            self.normalize_levels = False
+                    
         if self.normalize_levels == True:
             pLvlNowMean = np.mean(pLvlNow)
 


### PR DESCRIPTION
This implements a simple version of an old idea from CDC Mathematica code:  Simulation efficiency can be substantially improved by imposing on the stochastic draws facts that we know are true in the population, like that the average values of permanent and transitory shocks are 1 in each period.

