### PR TITLE
Add `aLvl` to `state_vars`

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -1580,7 +1580,7 @@ class PerfForesightConsumerType(AgentType):
     )
     time_vary_ = ["LivPrb", "PermGroFac"]
     time_inv_ = ["CRRA", "Rfree", "DiscFac", "MaxKinks", "BoroCnstArt" ]
-    state_vars = ['pLvl', 'PlvlAgg', 'bNrm', 'mNrm', "aNrm"]
+    state_vars = ['pLvl', 'PlvlAgg', 'bNrm', 'mNrm', "aNrm", 'aLvl']
     shock_vars_ = []
 
     def __init__(self, verbose=1, quiet=False, **kwds):


### PR DESCRIPTION
`aLvl` (`aNrm * pLvl`) is not a state that is required for solving or simulating the models in `ConsIndShockModel`. However, it was determined at some point in history that it was useful to keep track of `aLvl` as if it were a state. This is done for convenience and is mostly used in `ConsAggShockModel`.

See
https://github.com/econ-ark/HARK/blob/a11325ddfc1c403fd91a4120487a955ca30cded0/HARK/ConsumptionSaving/ConsIndShockModel.py#L1845-L1846

However, `aLvl` was never added to the list of state variables https://github.com/econ-ark/HARK/blob/a11325ddfc1c403fd91a4120487a955ca30cded0/HARK/ConsumptionSaving/ConsIndShockModel.py#L1583

This PR adds `aLvl` to the list of states so that `state_now` has the same entries as `state_vars`, which seems desirable to me.