### PR TITLE
IndexDstn rework

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -15,7 +15,8 @@ Release Date: TBD
 ### Major Changes
 
 * Updates the DCEGM tools to address the flaws identified in [issue #1062](https://github.com/econ-ark/HARK/issues/1062). PR: [1100](https://github.com/econ-ark/HARK/pull/1100).
-,
+* Updates `IndexDstn`, introducing the option to use an existing RNG instead of creating a new one, and creating and storing all the conditional distributions at initialization. [1104](https://github.com/econ-ark/HARK/pull/1104)
+
 ### Minor Changes
 
 ### 0.12.0

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -78,20 +78,33 @@ class IndexDistribution(Distribution):
 
         self.conditional = conditional
         self.engine = engine
-
-    def __getitem__(self, y):
-        # test one item to determine case handling
+        
+        
+        self.dstns = []
+        
+        # Test one item to determine case handling
         item0 = list(self.conditional.values())[0]
-
+        
         if type(item0) is list:
-            cond = {key: val[y] for (key, val) in self.conditional.items()}
-            return self.engine(seed=self.RNG.randint(0, 2 ** 31 - 1), **cond)
+            # Create and store all the conditional distributions
+            for y in range(len(item0)):
+                cond = {key: val[y] for (key, val) in self.conditional.items()}
+                self.dstns.append(self.engine(seed=self.RNG.randint(0, 2 ** 31 - 1), **cond))
+                
+        elif type(item0) is float:
+            
+            self.dstns = [self.engine(seed=self.RNG.randint(0, 2 ** 31 - 1), **conditional)]
+
         else:
             raise (
                 Exception(
                     f"IndexDistribution: Unhandled case for __getitem__ access. y: {y}; conditional: {self.conditional}"
                 )
             )
+            
+    def __getitem__(self, y):
+        
+        return self.dstns[y]
 
     def approx(self, N, **kwds):
         """
@@ -124,9 +137,7 @@ class IndexDistribution(Distribution):
 
         if type(item0) is float:
             # degenerate case. Treat the parameterization as constant.
-            return self.engine(
-                seed=self.RNG.randint(0, 2 ** 31 - 1), **self.conditional
-            ).approx(N, **kwds)
+            return self.dstns[0].approx(N, **kwds)
 
         if type(item0) is list:
             return TimeVaryingDiscreteDistribution(

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -62,9 +62,19 @@ class IndexDistribution(Distribution):
     conditional = None
     engine = None
 
-    def __init__(self, engine, conditional, seed=0):
-        # Set up the RNG
-        super().__init__(seed)
+    def __init__(self, engine, conditional, RNG = None, seed=0):
+        
+        if RNG is None:
+            # Set up the RNG
+            super().__init__(seed)
+        else:
+            # If an RNG is received, use it in whatever state it is in.
+            self.RNG = RNG
+            # The seed will still be set, even if it is not used for the RNG,
+            # for whenever self.reset() is called.
+            # Note that self.reset() will stop using the RNG that was passed
+            # and create a new one.
+            self.seed = seed
 
         self.conditional = conditional
         self.engine = engine


### PR DESCRIPTION
The current implementation of `IndexDstn` makes its random-number-generation work slightly different to what the majority of the HARK code currently does. Find the details in the discussion in https://github.com/econ-ark/HARK/pull/1024.

There is no right or wrong way to handle the RNG. Some might prefer what IndexDstn does, others might prefer what the legacy HARK code does. In the end both ways of doing things
a) Represent the same distributions when solving the agents' problems.
b) Draw shocks that follow the same (correct) distributions.

The issue is that the exact value of individual shocks is altered when one tries to replace legacy HARK code with the newer `IndexDstn` tool, and this breaks simulation tests.

This PR changes `IndexDstn` so that the user has the option of creating a new RNG (current behavior) or use an existing one (legacy HARK tests) to draw the seeds of the time-specific distributions that compose the `IndexDstn`.

This (I hope) will allow me to use `IndexDstn` and still pass tests. Eventually, if one random-number-generation method is favored over the others, we can go back and alter the tests accordingly (being sure that changes come only from RNG).

Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
