### PR TITLE
Allow unemp params to be None

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2650,16 +2650,16 @@ class IndShockConsumerType(PerfForesightConsumerType):
         TranShkCount : int
             The number of approximation points to be used in the discrete approxima-
             tion to the permanent income shock distribution.
-        UnempPrb : float
+        UnempPrb : float or [float]
             The probability of becoming unemployed during the working period.
-        UnempPrbRet : float
+        UnempPrbRet : float or None
             The probability of not receiving typical retirement income when retired.
         T_retire : int
             The index value for the final working period in the agent's life.
             If T_retire <= 0 then there is no retirement.
-        IncUnemp : float
+        IncUnemp : float or [float]
             Transitory income received when unemployed.
-        IncUnempRet : float
+        IncUnempRet : float or None
             Transitory income received while "unemployed" when retired.
         T_cycle :  int
             Total number of non-terminal periods in the consumer's sequence of periods.
@@ -2695,10 +2695,9 @@ class IndShockConsumerType(PerfForesightConsumerType):
             normal_length = T_cycle
             retire_length = 0
 
-        # Unemployment parametrs can be given either as:
         if all(
             [
-                isinstance(x, float)
+                isinstance(x, float) or (x is None)
                 for x in [UnempPrb, IncUnemp, UnempPrbRet, IncUnempRet]
             ]
         ):

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2697,7 +2697,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
 
         if all(
             [
-                isinstance(x, float) or (x is None)
+                isinstance(x, (float, int)) or (x is None)
                 for x in [UnempPrb, IncUnemp, UnempPrbRet, IncUnempRet]
             ]
         ):


### PR DESCRIPTION
My PR https://github.com/econ-ark/HARK/pull/1112 broke some outside functionality (DemARKs and some of @llorracc 's private scripts).

The crux appears to be that `UnempPrbRet` and related parameters can sometimes be `None`. This PR edits the income process constructor to accept that.

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
