### PR TITLE
[WIP] Arbitrary distributions of newborns' states

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -1586,8 +1586,11 @@ class PerfForesightConsumerType(AgentType):
     time_vary_ = ["LivPrb", "PermGroFac"]
     time_inv_ = ["CRRA", "Rfree", "DiscFac", "MaxKinks", "BoroCnstArt" ]
     state_vars = ['pLvl', 'PlvlAgg', 'bNrm', 'mNrm', "aNrm", 'aLvl']
-    newborn_init_vars = ["aNrm","pLvl"]
     shock_vars_ = []
+    
+    # Names and distribution of the states required to initialize an agent.
+    newborn_init_vars = ["aNrm","pLvl"]
+    newborn_state_dstn = None
 
     def __init__(self, verbose=1, quiet=False, **kwds):
         params = init_perfect_foresight.copy()
@@ -1605,9 +1608,6 @@ class PerfForesightConsumerType(AgentType):
         # Add consumer-type specific objects, copying to create independent versions
         self.time_vary = deepcopy(self.time_vary_)
         self.time_inv = deepcopy(self.time_inv_)
-        
-        # Distribution of newborns' initial conditions
-        self.newborn_state_dstn = None
         
         self.shock_vars = deepcopy(self.shock_vars_)
         self.verbose = verbose


### PR DESCRIPTION
It would be useful for us to let users specify whatever distribution they want for drawing the initial states of newborns.

For instance, I would like to draw the initial savings and permanent income levels of an `IndShockConsumerType` agent from some distribution calibrated to the SCF, not necessarily two independent lognormals as the current code requires.

This should be easy. Give me a `Distribution` object with the right dimensions and I will simply draw from it whenever agents are born. The issue, as usual is the current simulation tests (https://github.com/econ-ark/HARK/issues/1105).

This PR will contain my work towards the general-distribution-object purpose. I will try to find an elegant way not to break existing tests.

<!--- Put an `x` in all the boxes that apply: -->
- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
