### PR TITLE
'NewbornTransShk: Option if Newborns get transitory shock'

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -25,6 +25,7 @@ Release Date: TBD
 
 * Updates the lognormal-income-process constructor from `ConsIndShockModel.py` to use `IndexDistribution`. [#1024](https://github.com/econ-ark/HARK/pull/1024), [#1115](https://github.com/econ-ark/HARK/pull/1115)
 * Allows for age-varying unemployment probabilities and replacement incomes with the lognormal income process constructor. [#1112](https://github.com/econ-ark/HARK/pull/1112)
+* Option to have newborn IndShockConsumerType agents with a transitory income shock in the first period. Default is false, meaning they only have a permanent income shock in period 1 and permanent AND transitory in the following ones. [#1126](https://github.com/econ-ark/HARK/pull/1126)
 
 ### 0.12.0
 

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2177,8 +2177,9 @@ class IndShockConsumerType(PerfForesightConsumerType):
 
         Parameters
         ----------
-        None
-
+        NewbornTransShk : Boolean
+            Option if Newborns have transitory shock. Default is False.        
+        
         Returns
         -------
         None

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2046,7 +2046,7 @@ init_idiosyncratic_shocks = dict(
         "vFuncBool": False,  # Whether to calculate the value function during solution
         "CubicBool": False,  # Use cubic spline interpolation when True, linear interpolation when False
         "neutral_measure": False,      # Use permanent income neutral measure (see Harmenberg 2021) during simulations when True.
-        "NewbornTransShk":True, # Option if Newborns have no transitory shock. Default is True.
+        "NewbornTransShk":False, # Option if Newborns have transitory shock. Default is False.
     }
 )
 
@@ -2183,7 +2183,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
         -------
         None
         """
-        NewbornTransShk = self.NewbornTransShk #  Option if Newborns have no transitory shock. Default is True.
+        NewbornTransShk = self.NewbornTransShk #  Option if Newborns have transitory shock. Default is False.
 
         PermShkNow = np.zeros(self.AgentCount)  # Initialize shock arrays
         TranShkNow = np.zeros(self.AgentCount)
@@ -2224,8 +2224,8 @@ class IndShockConsumerType(PerfForesightConsumerType):
             )  # permanent "shock" includes expected growth
             TranShkNow[these] = IncShkDstnNow.X[1][EventDraws]
         #        PermShkNow[newborn] = 1.0
-        #  Option if Newborns have no transitory shock. Default is True.
-        if NewbornTransShk:
+        #  Option if Newborns have transitory shock. Default is False.
+        if not NewbornTransShk:
             TranShkNow[newborn] = 1.0
 
         # Store the shocks in self

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2046,7 +2046,7 @@ init_idiosyncratic_shocks = dict(
         "vFuncBool": False,  # Whether to calculate the value function during solution
         "CubicBool": False,  # Use cubic spline interpolation when True, linear interpolation when False
         "neutral_measure": False,      # Use permanent income neutral measure (see Harmenberg 2021) during simulations when True.
-        "NewbornTransShk":False, # Option if Newborns have transitory shock. Default is False.
+        "NewbornTransShk":False, # Whether Newborns have transitory shock. The default is False.
     }
 )
 
@@ -2177,14 +2177,14 @@ class IndShockConsumerType(PerfForesightConsumerType):
 
         Parameters
         ----------
-        NewbornTransShk : Boolean
-            Option if Newborns have transitory shock. Default is False.        
+        NewbornTransShk : boolean, optional
+            Whether Newborns have transitory shock. The default is False.        
         
         Returns
         -------
         None
         """
-        NewbornTransShk = self.NewbornTransShk #  Option if Newborns have transitory shock. Default is False.
+        NewbornTransShk = self.NewbornTransShk #  Whether Newborns have transitory shock. The default is False.
 
         PermShkNow = np.zeros(self.AgentCount)  # Initialize shock arrays
         TranShkNow = np.zeros(self.AgentCount)
@@ -2225,7 +2225,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
             )  # permanent "shock" includes expected growth
             TranShkNow[these] = IncShkDstnNow.X[1][EventDraws]
         #        PermShkNow[newborn] = 1.0
-        #  Option if Newborns have transitory shock. Default is False.
+        #  Whether Newborns have transitory shock. The default is False.
         if not NewbornTransShk:
             TranShkNow[newborn] = 1.0
 

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2046,6 +2046,7 @@ init_idiosyncratic_shocks = dict(
         "vFuncBool": False,  # Whether to calculate the value function during solution
         "CubicBool": False,  # Use cubic spline interpolation when True, linear interpolation when False
         "neutral_measure": False,      # Use permanent income neutral measure (see Harmenberg 2021) during simulations when True.
+        "NewbornTransShk":True, # Option if Newborns have no transitory shock. Default is True.
     }
 )
 
@@ -2182,6 +2183,8 @@ class IndShockConsumerType(PerfForesightConsumerType):
         -------
         None
         """
+        NewbornTransShk = self.NewbornTransShk #  Option if Newborns have no transitory shock. Default is True.
+
         PermShkNow = np.zeros(self.AgentCount)  # Initialize shock arrays
         TranShkNow = np.zeros(self.AgentCount)
         newborn = self.t_age == 0
@@ -2221,7 +2224,9 @@ class IndShockConsumerType(PerfForesightConsumerType):
             )  # permanent "shock" includes expected growth
             TranShkNow[these] = IncShkDstnNow.X[1][EventDraws]
         #        PermShkNow[newborn] = 1.0
-        TranShkNow[newborn] = 1.0
+        #  Option if Newborns have no transitory shock. Default is True.
+        if NewbornTransShk:
+            TranShkNow[newborn] = 1.0
 
         # Store the shocks in self
         self.EmpNow = np.ones(self.AgentCount, dtype=bool)


### PR DESCRIPTION
Pull request for issue:
Newborns' transitory shocks to income #1125

I added an aditional variable: NewbornTransShk which is by default true. If so, Newborn consumers do NOT get a transitory shock in the first period, only a permanent one.
By setting it 'False' Newborn consumers Do get a transitory shock as well.
