### PR TITLE
Fix normal equiprobable approximation

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -27,6 +27,7 @@ Release Date: TBD
 * Allows for age-varying unemployment probabilities and replacement incomes with the lognormal income process constructor. [#1112](https://github.com/econ-ark/HARK/pull/1112)
 * Option to have newborn IndShockConsumerType agents with a transitory income shock in the first period. Default is false, meaning they only have a permanent income shock in period 1 and permanent AND transitory in the following ones. [#1126](https://github.com/econ-ark/HARK/pull/1126)
 * Adds `benchmark` utility to profile the performance of `HARK` solvers. [#1131](https://github.com/econ-ark/HARK/pull/1131)
+* Fixes scaling bug in Normal equiprobable approximation method. [1139](https://github.com/econ-ark/HARK/pull/1139)
 
 ### 0.12.0
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -527,14 +527,14 @@ class Normal(Distribution):
         )
 
     def approx_equiprobable(self, N):
+        
         CDF = np.linspace(0, 1, N + 1)
         lims = stats.norm.ppf(CDF)
-        scores = (lims - self.mu) / self.sigma
-        pdf = stats.norm.pdf(scores)
+        pdf = stats.norm.pdf(lims)
 
         # Find conditional means using Mills's ratio
         pmf = np.diff(CDF)
-        X = self.mu - np.diff(pdf) / pmf
+        X = self.mu - np.diff(pdf) / pmf * self.sigma
 
         return DiscreteDistribution(
             pmf, X, seed=self.RNG.randint(0, 2 ** 31 - 1, dtype="int32")

--- a/HARK/tests/test_distribution.py
+++ b/HARK/tests/test_distribution.py
@@ -214,15 +214,14 @@ class LogNormalToNormalTests(unittest.TestCase):
 
         self.assertAlmostEqual(avg_n, avg_hat)
         self.assertAlmostEqual(std_n, std_hat)
-        
+
+
 class NormalDistTest(unittest.TestCase):
-    
     def test_approx_equiprobable(self):
-        
+
         mu, sigma = 5.0, 27.0
-        
+
         points = Normal(mu, sigma).approx_equiprobable(701).X
-        
-        self.assertAlmostEqual(np.mean(points), mu, places = 7)
-        self.assertAlmostEqual(np.std(points), sigma, places = 2)
-        
+
+        self.assertAlmostEqual(np.mean(points), mu, places=7)
+        self.assertAlmostEqual(np.std(points), sigma, places=2)

--- a/HARK/tests/test_distribution.py
+++ b/HARK/tests/test_distribution.py
@@ -214,3 +214,15 @@ class LogNormalToNormalTests(unittest.TestCase):
 
         self.assertAlmostEqual(avg_n, avg_hat)
         self.assertAlmostEqual(std_n, std_hat)
+        
+class NormalDistTest(unittest.TestCase):
+    
+    def test_approx_equiprobable(self):
+        
+        mu, sigma = 5.0, 27.0
+        
+        points = Normal(mu, sigma).approx_equiprobable(701).X
+        
+        self.assertAlmostEqual(np.mean(points), mu, places = 7)
+        self.assertAlmostEqual(np.std(points), sigma, places = 2)
+        


### PR DESCRIPTION
I noticed a bug in the code that discretizes normal distributions using an equiprobable approximation. This is code that I added some months ago. I was not re-scaling the points from their standardized transformation appropriately.

This PR fixes the issue and adds a test.

I do not think this bug has any major impact:
- Equiprobable is not the default discretization method for the normal distribution.
- The normal distribution is not used much (at all?) around HARK. Most shocks are lognormal.

I'll only have to revise my estimate of my statistical proficiency downward.
