### PR TITLE
Tool to find the distribution of a function of a R.V.

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -19,6 +19,7 @@ Release Date: TBD
 * `make_shock_history` and `read_shocks == True` now store and use the random draws that determine newborn's initial states [#1101](https://github.com/econ-ark/HARK/pull/1101).
 * `FrameModel` and `FrameSet` classes introduced for more modular construction of framed models. `FrameAgentType` dedicated to simulation. [#1117](https://github.com/econ-ark/HARK/pull/1117)
 * General control transitions based on decision rules in `FrameAgentType`. [#1117](https://github.com/econ-ark/HARK/pull/1117)
+* Adds `distr_of_function` tool to calculate the distribution of a function of a discrete random variable. [#1144](https://github.com/econ-ark/HARK/pull/1144)
 
 
 ### Minor Changes

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -1374,11 +1374,14 @@ def distr_of_function(dstn, func=lambda x: x, *args):
         The distribution of func(dstn).
     """
     if dstn.dim() == 1:
-        f_of_X = np.array(list(map(func, np.array(dstn.X)))).T
+        f_of_X = np.array([func(x, *args) for x in dstn.X]).T
     else:
-        f_of_X = np.apply_along_axis(lambda x: func(*x), 0, np.array(dstn.X))
+        f_of_X = np.apply_along_axis(func, 0, np.array(dstn.X), *args)
 
-    f_dstn = DiscreteDistribution(dstn.pmf, [f_of_X[i, :] for i in range(f_of_X.shape[0])])
+    if len(f_of_X.shape) == 1:
+        f_dstn = DiscreteDistribution(dstn.pmf, f_of_X)
+    else:
+        f_dstn = DiscreteDistribution(dstn.pmf, [f_of_X[i, :] for i in range(f_of_X.shape[0])])
 
     return f_dstn
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -1346,6 +1346,41 @@ def calc_expectation(dstn, func=lambda x: x, *args):
 
     return f_exp
 
+def distr_of_function(dstn, func=lambda x: x, *args):
+    """
+    Finds the distribution of a random variable Y that is a function
+    of discrete random variable X, Y=f(X).
+
+    Parameters
+    ----------
+    dstn : DiscreteDistribution
+        The N-valued distribution over which the function is to be evaluated.
+    func : function
+        The function to be evaluated.
+        This function should take an array of size N x M.
+        It may also take other arguments *args
+        Please see numpy.apply_along_axis() for guidance on
+        design of func.
+        Defaults to identity function.
+    *args : scalar or np.array
+        One or more constants or arrays of input values for func,
+        representing the non-stochastic arguments.
+        The arrays must all have the same shape, and the function is computed
+        at f(dstn, args[0], args[1],...,args[M]).
+
+    Returns
+    -------
+    f_dstn : DiscreteDistribution
+        The distribution of func(dstn).
+    """
+    if dstn.dim() == 1:
+        f_of_X = np.array(list(map(func, np.array(dstn.X)))).T
+    else:
+        f_of_X = np.apply_along_axis(lambda x: func(*x), 0, np.array(dstn.X))
+
+    f_dstn = DiscreteDistribution(dstn.pmf, [f_of_X[i, :] for i in range(f_of_X.shape[0])])
+
+    return f_dstn
 
 class MarkovProcess(Distribution):
     """

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -1346,6 +1346,7 @@ def calc_expectation(dstn, func=lambda x: x, *args):
 
     return f_exp
 
+
 def distr_of_function(dstn, func=lambda x: x, *args):
     """
     Finds the distribution of a random variable Y that is a function
@@ -1381,7 +1382,9 @@ def distr_of_function(dstn, func=lambda x: x, *args):
     if len(f_of_X.shape) == 1:
         f_dstn = DiscreteDistribution(dstn.pmf, f_of_X)
     else:
-        f_dstn = DiscreteDistribution(dstn.pmf, [f_of_X[i, :] for i in range(f_of_X.shape[0])])
+        f_dstn = DiscreteDistribution(
+            dstn.pmf, [f_of_X[i, :] for i in range(f_of_X.shape[0])]
+        )
 
     return f_dstn
 

--- a/HARK/tests/test_distribution.py
+++ b/HARK/tests/test_distribution.py
@@ -33,23 +33,20 @@ class DiscreteDistributionTests(unittest.TestCase):
             0,
         )
 
-    def test_distr_of_function(self): 
-        
+    def test_distr_of_function(self):
+
         # Function 1 -> 1
         # Approximate the lognormal expectation
         sig = 0.05
-        norm = Normal(mu = -sig**2/2, sigma = sig).approx(131)
-        my_logn = distr_of_function(norm, func = lambda x: np.exp(x))
+        norm = Normal(mu=-(sig ** 2) / 2, sigma=sig).approx(131)
+        my_logn = distr_of_function(norm, func=lambda x: np.exp(x))
         exp = calc_expectation(my_logn)
         self.assertAlmostEqual(exp, 1.0)
 
         # Function 1 -> n
         # Mean and variance of the normal
-        norm = Normal(mu=0.0, sigma = 1.0).approx(5)
-        moments = distr_of_function(
-            norm,
-            lambda x: np.array([x, x**2])
-        )
+        norm = Normal(mu=0.0, sigma=1.0).approx(5)
+        moments = distr_of_function(norm, lambda x: np.array([x, x ** 2]))
         exp = calc_expectation(moments)
         self.assertAlmostEqual(exp[0], 0.0)
         self.assertAlmostEqual(exp[1], 1.0)
@@ -58,8 +55,8 @@ class DiscreteDistributionTests(unittest.TestCase):
         # Expectation of the sum of two independent normals
         mu_a, mu_b = 1.0, 2.0
         si_a, si_b = 3.0, 4.0
-        norm_a = Normal(mu=mu_a, sigma = si_a).approx(5)
-        norm_b = Normal(mu=mu_b, sigma = si_b).approx(5)
+        norm_a = Normal(mu=mu_a, sigma=si_a).approx(5)
+        norm_b = Normal(mu=mu_b, sigma=si_b).approx(5)
         binorm = combine_indep_dstns(norm_a, norm_b)
         mysum = distr_of_function(binorm, lambda x: np.sum(x))
         exp = calc_expectation(mysum)
@@ -69,13 +66,13 @@ class DiscreteDistributionTests(unittest.TestCase):
         # Mean and variance of two normals
         moments = distr_of_function(
             binorm,
-            lambda x: np.array([x[0], (x[0]-mu_a)**2, x[1], (x[1] - mu_b)**2])
+            lambda x: np.array([x[0], (x[0] - mu_a) ** 2, x[1], (x[1] - mu_b) ** 2]),
         )
         exp = calc_expectation(moments)
         self.assertAlmostEqual(exp[0], mu_a)
-        self.assertAlmostEqual(exp[1], si_a**2)
+        self.assertAlmostEqual(exp[1], si_a ** 2)
         self.assertAlmostEqual(exp[2], mu_b)
-        self.assertAlmostEqual(exp[3], si_b**2)
+        self.assertAlmostEqual(exp[3], si_b ** 2)
 
     def test_calc_expectation(self):
         dd_0_1_20 = Normal().approx(20)


### PR DESCRIPTION
Imagine `x` is a `DiscreteDistribution` object and you want to find the distribution of `f(x)` for some `f`.

This pr introduces a tool called `distr_of_function`. `distr_of_function(x, f)` will return a `DiscreteDistribution` object that represents the distribution of `f(x)`. I wrote tests and made it work for `f: 1->1`, `f: n->1`, `f: 1->n`, and `f: n->m`. You only need `f` to return a `np.array`. 

Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
