### PR TITLE
[WIP] Multilinear wrapper for econforge.interpolation

### DIFF
--- a/HARK/econforgeinterp.py
+++ b/HARK/econforgeinterp.py
@@ -1,0 +1,32 @@
+from .core import MetricObject
+from interpolation.splines import eval_linear, UCGrid
+from interpolation.splines import extrap_options as xto
+
+import numpy as np
+from copy import copy
+
+
+class LinearFast(MetricObject):
+
+    distance_criteria = ["f_val", "grid_list"]
+
+    def __init__(self, f_val, grids, extrap_options=None):
+
+        self.dim = len(grids)
+        self.f_val = f_val
+        self.grid_list = grids
+        self.Grid = UCGrid(*grids)
+        self.extrap_options = extrap_options
+
+    def __call__(self, *args):
+
+        array_args = [np.asarray(x) for x in args]
+
+        f = eval_linear(
+            self.Grid,
+            self.f_val,
+            np.column_stack([x.flatten() for x in array_args]),
+            self.extrap_options,
+        )
+
+        return np.reshape(f, array_args[0].shape)

--- a/HARK/econforgeinterp.py
+++ b/HARK/econforgeinterp.py
@@ -7,19 +7,43 @@ from copy import copy
 
 
 class LinearFast(MetricObject):
+    """
+    A class that constructs and holds all the necessary elements to
+    call a multilinear interpolator from econforge.interpolator in
+    a way that resembles the basic interpolators in HARK.interpolation.
+    """
 
     distance_criteria = ["f_val", "grid_list"]
 
     def __init__(self, f_val, grids, extrap_options=None):
-
+        """
+        f_val: numpy.array
+            An array containing the values of the function at the grid points.
+            It's i-th dimension must be of the same lenght as the i-th grid.
+            f_val[i,j,k] must be f(grids[0][i], grids[1][j], grids[2][k]).
+        grids: [numpy.array]
+            One-dimensional list of numpy arrays. It's i-th entry must be the grid
+            to be used for the i-th independent variable.
+        extrap_options: None or one of xto.NEAREST, xto.LINEAR, or xto.CONSTANT from
+            the extrapolation options of econforge.interpolation.
+            Determines how to extrapolate, using either nearest point, multilinear, or 
+            constant extrapolation. The default is multilinear.
+        """
         self.dim = len(grids)
         self.f_val = f_val
         self.grid_list = grids
         self.Grid = UCGrid(*grids)
-        self.extrap_options = extrap_options
+        self.extrap_options = xto.LINEAR if extrap_options is None else extrap_options
 
     def __call__(self, *args):
-
+        """
+        Calls the interpolator.
+        
+        args: [numpy.array]
+            List of arrays. The i-th entry contains the i-th coordinate
+            of all the points to be evaluated. All entries must have the
+            same shape.
+        """
         array_args = [np.asarray(x) for x in args]
 
         f = eval_linear(

--- a/HARK/tests/test_econforgeinterp.py
+++ b/HARK/tests/test_econforgeinterp.py
@@ -1,0 +1,139 @@
+from typing import no_type_check_decorator
+import unittest
+import numpy as np
+
+from HARK.interpolation import LinearInterp, BilinearInterp
+from HARK.econforgeinterp import LinearFast
+from HARK.core import distance_metric
+
+
+class CompareLinearInterp(unittest.TestCase):
+    """ 
+    Compares output and properties with the basic linearinterp
+    """
+
+    def setUp(self):
+
+        self.n_grid_points = 100
+        self.n_eval_points = 3
+
+    def compare_output(self, x, y, eval_points):
+
+        h_interp = LinearInterp(x, y, lower_extrap=True)
+        e_interp = LinearFast(y, [x])
+
+        h_vals = h_interp(eval_points)
+        e_vals = e_interp(eval_points)
+        self.assertTrue(np.allclose(h_vals, e_vals))
+
+    def test_outputs(self):
+        """
+        Tests that function calls using the base hark and
+        econforge implementations return the same.
+        """
+        # Square function
+        x = np.linspace(0, 10, self.n_grid_points)
+        y = np.power(x, 2)
+
+        # Interpolation
+        in_points = np.linspace(2, 8, self.n_eval_points)
+        self.compare_output(x, y, in_points)
+
+        # Extrapolation
+        ex_points = np.linspace(-10, 20, self.n_eval_points)
+        self.compare_output(x, y, ex_points)
+
+    def test_metric(self):
+        """
+        Tests that the interpolator metric called on a pair of
+        interpolator objects is the same for hark and econforge
+        interps
+        """
+        n_points = 10
+
+        x0 = np.exp(np.linspace(0, 1, n_points))
+        y0 = np.sin(x0)
+
+        x1 = np.linspace(-10, 20, n_points)
+        y1 = 0.5 * x1 + 2
+
+        # Distance with HARK
+        h_dist = distance_metric(LinearInterp(x0, y0), LinearInterp(x1, y1))
+        # Distance with econforge
+        e_dist = distance_metric(LinearFast(y0, [x0]), LinearFast(y1, [x1]))
+
+        self.assertAlmostEqual(h_dist, e_dist)
+
+
+class CompareBilinearInterp(unittest.TestCase):
+    """ 
+    Compares output and properties with the basic linearinterp
+    """
+
+    def setUp(self):
+
+        self.n_grid_points = 100
+        self.n_eval_points = 3
+
+    def compare_output(self, x, y, z, eval_x, eval_y):
+
+        h_interp = BilinearInterp(z, x, y)
+        e_interp = LinearFast(z, [x, y])
+
+        h_vals = h_interp(eval_x, eval_y)
+        e_vals = e_interp(eval_x, eval_y)
+        self.assertTrue(np.allclose(h_vals, e_vals))
+
+    def test_outputs(self):
+        """
+        Tests that function calls using the base hark and
+        econforge implementations return the same.
+        """
+        # Sum of squares function
+        x_grid = np.linspace(0, 10, self.n_grid_points)
+        y_grid = np.linspace(0, 10, self.n_grid_points)
+
+        x_tiled, y_tiled = np.meshgrid(x_grid, y_grid, indexing="ij")
+
+        z = np.power(x_tiled, 2) + np.power(y_tiled, 2)
+
+        # Interpolation
+        x_in, y_in = np.meshgrid(
+            np.linspace(2, 8, self.n_eval_points),
+            np.linspace(2, 8, self.n_eval_points),
+            indexing="ij",
+        )
+        self.compare_output(x_grid, y_grid, z, x_in, y_in)
+
+        # Extrapolation
+        x_ex, y_ex = np.meshgrid(
+            np.linspace(-10, 20, self.n_eval_points),
+            np.linspace(-10, 20, self.n_eval_points),
+            indexing="ij",
+        )
+        self.compare_output(x_grid, y_grid, z, x_ex, y_ex)
+
+    def test_metric(self):
+        """
+        Tests that the interpolator metric called on a pair of
+        interpolator objects is the same for hark and econforge
+        interps
+        """
+        n_points = 10
+
+        x0 = np.exp(np.linspace(0, 1, n_points))
+        y0 = np.linspace(3, 4, n_points)
+        x0_t, y0_t = np.meshgrid(x0, y0, indexing="ij")
+        z0 = np.sin(x0_t) + y0_t
+
+        x1 = np.linspace(-10, 20, n_points)
+        y1 = 0.5 * x1 + 2
+        x1_t, y1_t = np.meshgrid(x1, y1, indexing="ij")
+        z1 = x1_t + y1_t
+
+        # Distance with HARK
+        h_dist = distance_metric(BilinearInterp(z0, x0, y0), BilinearInterp(z1, x1, y1))
+        # Distance with econforge
+        e_dist = distance_metric(LinearFast(z0, [x0, y0]), LinearFast(z1, [x1, y1]))
+
+        self.assertAlmostEqual(h_dist, e_dist)


### PR DESCRIPTION
This PR adds a simple wrapper for multilinear interpolators from `econforge.interpolation`.

https://github.com/econ-ark/HARK/pull/1136 had some progress on this, but I believe the person in charge is no longer working on HARK. In addition, my simple class works for any dimension (linear, bilinear, trilinear); I've added tests that show how to use it and compare its output with HARK's current classes.

I was careful to also check for `distance metrics`, which might not seem important, but are what determines when to stop when solving an infinite horizon problem. My objects yield the same distance metrics as `LinearInterp` and `BilinearInterp`.

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
