### PR TITLE
Patch LinearFast after interpolation release

### DIFF
--- a/HARK/econforgeinterp.py
+++ b/HARK/econforgeinterp.py
@@ -1,5 +1,5 @@
 from .core import MetricObject
-from interpolation.splines import eval_linear, UCGrid
+from interpolation.splines import eval_linear, CGrid
 from interpolation.splines import extrap_options as xto
 
 import numpy as np
@@ -32,7 +32,7 @@ class LinearFast(MetricObject):
         self.dim = len(grids)
         self.f_val = f_val
         self.grid_list = grids
-        self.Grid = UCGrid(*grids)
+        self.Grid = CGrid(*grids)
         self.extrap_options = xto.LINEAR if extrap_options is None else extrap_options
 
     def __call__(self, *args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ sphinx-rtd-theme
 nbsphinx
 seaborn
 recommonmark
-interpolation
+interpolation>=2.2.3
 numba
 quantecon
 pandas


### PR DESCRIPTION
The latest `interpolation.py` release requires irregular grids to be created using `CGrid` and not `UCGrid`, which breaks `LinearFast`.

This fixes the issue.

Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
