### PR TITLE
Add seed as property of DiscreteDstnLabeled

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -46,6 +46,7 @@ Release Date: TBD
 * Updates asset grid constructor from `ConsIndShockModel.py` to allow for linearly-spaced grids when `aXtraNestFac == -1`. [#1172](https://github.com/econ-ark/HARK/pull/1172)
 * Renames `DiscreteDistributionXRA` to `DiscreteDistributionLabeled` and updates methods [#1170](https://github.com/econ-ark/HARK/pull/1170)
 * Renames `HARK.numba` to `HARK.numba_tools` [#1183](https://github.com/econ-ark/HARK/pull/1183)
+* Adds the RNG seed as a property of `DiscreteDistributionLabeled` [#1184](https://github.com/econ-ark/HARK/pull/1184)
 
 ### 0.12.0
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -1171,6 +1171,13 @@ class DiscreteDistributionLabeled(DiscreteDistribution):
         return self.pmf.values
 
     @property
+    def seed(self):
+        """
+        Returns the distribution's seed.
+        """
+        return self.dataset.seed
+
+    @property
     def RNG(self):
         """
         Returns the distribution's random number generator.


### PR DESCRIPTION
I'm starting to use @alanlujan91 's excellent DDL tools.

I noticed a small bug. Some of the discrete distribution features that are extended to DDL expect to be able to access `DDL.seed`. However, the seed is located in `DDL.dataset.seed`; requesting `DDL.seed` returns an error.

This PR fixes the bug by declaring the seed as a property.

Here is an example of code that fails for me without this fix
```
from HARK.distribution import DiscreteDistributionLabeled
import numpy as np

my_dstn = DiscreteDistributionLabeled(
    pmv = np.array([0.5,0.5]),
    data = np.array([-1,1]),
    var_names = ['my_var']
)
my_dstn.dataset

sq_dstn = my_dstn.dist_of_func(lambda x: x['my_var']**2)
sq_dstn.atoms
``` 

<!--- Put an `x` in all the boxes that apply: -->
- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
