### PR TITLE
[WIP] Vector-valued interpolation in `econforgeinterp`

### DIFF
--- a/HARK/tests/test_econforgeinterp.py
+++ b/HARK/tests/test_econforgeinterp.py
@@ -375,3 +375,39 @@ class TestLinearDecay(unittest.TestCase):
         efor_vals = efor_lim_interp(x_eval)
 
         self.assertTrue(np.allclose(base_vals, efor_vals))
+
+
+class Test2Dto2DInterp(unittest.TestCase):
+    def f1(self, x, y):
+        return 2 * x + y
+
+    def f2(self, x, y):
+        return 3 * x + 2 * y
+
+    def setUp(self):
+        self.x = np.linspace(0, 10, 11)
+        self.y = np.linspace(0, 10, 11)
+        x_t, y_t = np.meshgrid(self.x, self.y, indexing="ij")
+
+        # Create interpolator
+        self.interp = LinearFast(
+            [self.f1(x_t, y_t), self.f2(x_t, y_t)],
+            [self.x, self.y],
+            extrap_mode="linear",
+        )
+
+    def test_outputs(self):
+        # Create random x-y points
+        x_eval = np.random.rand(100) * 10
+        y_eval = np.random.rand(100) * 10
+
+        # Evaluete functions
+        f1_eval = self.f1(x_eval, y_eval)
+        f2_eval = self.f2(x_eval, y_eval)
+
+        # Evaluate interpolator
+        f1_inter, f2_inter = self.interp(x_eval, y_eval)
+
+        # Compare outputs
+        self.assertTrue(np.allclose(f1_eval, f1_inter))
+        self.assertTrue(np.allclose(f2_eval, f2_inter))


### PR DESCRIPTION
`econforgeinterp` (and all other interpolators in HARK) currently support interpolation of scalar valued functions, $f:\mathbb{R}^n\rightarrow \mathbb{R}$. I would like to work on adding the capability to interpolate vector-valued functions, $f:\mathbb{R}^n\rightarrow \mathbb{R^m}$.

The current version of this PR makes this possible in the barebones `LinearFast`. I still need to adjust the extra-stuff: derivatives and decay-interpolation.

## Why do I think this would be useful?

In a model with, say, a 2-dimensional state space, we often will construct a bunch of interpolators for `vFunc(m,n)`, `dvdmFunc(m,n)`, `dvdnFunc(m,n)`, `cFunc(m,n)`... over the same `(m,n)` grids.

Often, in the expectation step of backward induction, we will need to evaluate, say `dvdmFunc(m,n)`, `dvdnFunc(m,n)` in a bunch of points. We can do this with two different interpolators, one for each function. But this does the slow calculation of which indices and weights to use for interpolation twice for every point (once in each interpolator). If we instead had an
$\mathbb{R}^2\rightarrow \mathbb{R^2}$ interpolator of `(m,n) -> [dvdmFunc(m,n), dvdnFunc(m,n)]` the calculation of indices and weights would be done only once.

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
