### PR TITLE
Allow risky return draws to be agent-specific.

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -8,6 +8,15 @@ For more information on HARK, see [our Github organization](https://github.com/e
 
 ## Changes
 
+### 0.13.1
+
+Release Date: TBD
+
+### Major Changes
+
+### Minor Changes
+- Adds option `sim_common_Rriksy` to control whether risky-asset models draw common or idiosyncratic returns in simulation. [#1250](https://github.com/econ-ark/HARK/pull/1250)
+
 ### 0.13.0
 
 Release Date: February, 16, 2023

--- a/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
@@ -61,6 +61,11 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
         if not hasattr(self, "PortfolioBisect"):
             self.PortfolioBisect = False
 
+        # Boolean determines whether, when simulating a given time period,
+        # all agents will draw the same risky return factor (true by default)
+        if not hasattr(self, "sim_common_Rriksy"):
+            self.sim_common_Rriksy = True
+
         # Initialize a basic consumer type
         IndShockConsumerType.__init__(self, verbose=verbose, quiet=quiet, **kwds)
 
@@ -319,9 +324,15 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
             RiskyAvg = self.RiskyAvg
             RiskyStd = self.RiskyStd
 
-        self.shocks["Risky"] = Lognormal.from_mean_std(
-            RiskyAvg, RiskyStd, seed=self.RNG.integers(0, 2**31 - 1)
-        ).draw(1)
+        # Draw either a common economy-wide return, or one for each agent
+        if self.sim_common_Rriksy:
+            self.shocks["Risky"] = Lognormal.from_mean_std(
+                RiskyAvg, RiskyStd, seed=self.RNG.integers(0, 2**31 - 1)
+            ).draw(1)
+        else:
+            self.shocks["Risky"] = Lognormal.from_mean_std(
+                RiskyAvg, RiskyStd, seed=self.RNG.integers(0, 2**31 - 1)
+            ).draw(self.AgentCount)
 
     def get_Adjust(self):
         """
@@ -1307,7 +1318,7 @@ risky_asset_parms = {
     "AdjustPrb": 1.0,
     # When simulating the model, should all agents get the same risky return in
     # a given period?
-    "sim_common_Rriksy": True, 
+    "sim_common_Rriksy": True,
 }
 
 # Make a dictionary to specify a risky asset consumer type

--- a/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
@@ -1305,6 +1305,9 @@ risky_asset_parms = {
     "RiskyCount": 5,
     # Probability that the agent can adjust their portfolio each period
     "AdjustPrb": 1.0,
+    # When simulating the model, should all agents get the same risky return in
+    # a given period?
+    "sim_common_Rriksy": True, 
 }
 
 # Make a dictionary to specify a risky asset consumer type

--- a/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
@@ -222,3 +222,36 @@ class testPortfolioConsumerTypeDiscreteAndJoint(unittest.TestCase):
 
         # Solve model under given parameters
         self.discrete_and_joint.solve()
+
+
+class testRiskyReturnDim(PortfolioConsumerTypeTestCase):
+    def test_simulation(self):
+        # Setup
+        self.pcct.T_sim = 30
+        self.pcct.AgentCount = 10
+        self.pcct.track_vars += [
+            "mNrm",
+            "cNrm",
+            "Risky",
+        ]
+        # Common (default) simulation
+        self.pcct.initialize_sim()
+        self.pcct.simulate()
+        # Assety that all columns of Risky are the same
+        self.assertTrue(
+            np.all(
+                self.pcct.history["Risky"]
+                == self.pcct.history["Risky"][:, 0][:, np.newaxis]
+            )
+        )
+        # Agent specific simulation
+        self.pcct.sim_common_Rriksy = False
+        self.pcct.initialize_sim()
+        self.pcct.simulate()
+        # Assety that all columns of Risky are not the same
+        self.assertFalse(
+            np.all(
+                self.pcct.history["Risky"]
+                == self.pcct.history["Risky"][:, 0][:, np.newaxis]
+            )
+        )


### PR DESCRIPTION
Our current implementation of models with risky returns impose the restriction that, when simulating, a single economy-wide return is drawn every period.

This PR adds the option for the returns that are drawn in simulation to be agent-specific.

This is useful, for instance, if you are doing a monte-carlo simulation to find the average consumption at age 45 implied by your model. With the current restriction, there is some inefficiency in the fact that agents' lives are correlated through return draws. Drawing a different shock for every agent breaks this correlation, and (I think?) increases the efficiency of the estimator (for a given `AgentCount` and `T_sim`).

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
