### PR TITLE
N-dimensional 'jump_to_grid'

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+    patch:
+      default:
+        target: 50%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 70%
-    patch:
-      default:
-        target: 50%

--- a/HARK/mat_methods.py
+++ b/HARK/mat_methods.py
@@ -1,0 +1,256 @@
+import numpy as np
+from numba import njit
+from typing import List
+
+
+@njit
+def ravel_index(ind_mat: np.ndarray, dims: np.ndarray) -> np.ndarray:
+    """
+    This function takes a matrix of indices, and a vector of dimensions, and
+    returns a vector of corresponding flattened indices
+    """
+    # Initialize indices
+    r_ind = np.zeros(ind_mat.shape[1:], dtype=np.int64)
+    # Find index multipliers
+    cdims = np.concatenate((np.cumprod(dims[1:][::-1])[::-1], np.array([1])))
+    for i, cdim in enumerate(cdims):
+        r_ind += ind_mat[i] * cdim
+
+    return r_ind
+
+
+@njit
+def multidim_get_lower_index(
+    points: np.ndarray, grids: List[np.ndarray], dims: np.ndarray
+) -> np.ndarray:
+    """
+    Get the lower index for each point in a multidimensional grid.
+
+    Parameters
+    ----------
+    points : np.ndarray
+        The points for which to find the lower index.
+    grids : List[np.ndarray]
+        The grids for each dimension.
+    dims : np.ndarray
+        The dimensions of the grids.
+
+    Returns
+    -------
+    np.ndarray
+        The indices of the lower grid point for each point in each dimension.
+    """
+    inds = np.empty_like(points, dtype=np.int64)
+    for i, grid in enumerate(grids):
+        inds[:, i] = np.minimum(
+            np.searchsorted(grid, points[:, i], side="right") - 1, dims[i] - 2
+        )
+
+    return inds
+
+
+@njit
+def fwd_and_bwd_diffs(
+    points: np.ndarray, grids: List[np.ndarray], inds: np.ndarray
+) -> np.ndarray:
+    """
+    Computes backward and forward differences for each point in points for each grid in grids.
+
+    Parameters
+    ----------
+    points : np.ndarray
+        The points for which to compute the differences.
+    grids : List[np.ndarray]
+        The grids for each dimension.
+    inds : np.ndarray
+        The indices of the lower grid point for each point in each dimension.
+
+    Returns
+    -------
+    np.ndarray
+        A (2, ndim, npoints) matrix in which [:,i,:] is the backward and forward difference for the ith dimension.
+    """
+    # Preallocate
+    diffs = np.empty((2, points.shape[1], points.shape[0]))
+
+    for i, grid in enumerate(grids):
+        # Backward
+        diffs[0, i, :] = points[:, i] - grid[inds[i, :]]
+        # Forward
+        diffs[1, i, :] = grid[inds[i, :] + 1] - points[:, i]
+
+    return diffs
+
+
+@njit
+def sum_weights(
+    weights: np.ndarray, dims: np.ndarray, add_inds: np.ndarray
+) -> np.ndarray:
+    """
+    Sums the weights that correspond to each point in the grid.
+
+    Parameters
+    ----------
+    weights : np.ndarray
+        The weights to be summed.
+    dims : np.ndarray
+        The dimensions of the grid.
+    add_inds : np.ndarray
+        The indices of the points in the grid to which the weights correspond.
+
+    Returns
+    -------
+    np.ndarray
+        The sum of the weights for each point in the grid (flattened).
+    """
+    # Initialize arary to hold weights.
+    distr = np.zeros(np.prod(dims), dtype=np.float64)
+
+    # Add weights point by point
+    for i in range(weights.shape[1]):
+        distr[add_inds[:, i]] += weights[:, i]
+
+    return distr
+
+
+@njit
+def denominators(inds: np.ndarray, grids: List[np.ndarray]) -> np.ndarray:
+    """
+    This function computes the denominators of the interpolation weights,
+    which are the areas of the hypercubes of the grid that contain the points.
+
+    Parameters
+    ----------
+    inds : np.ndarray
+        The indices of the lower grid point for each point in each dimension.
+    grids : List[np.ndarray]
+        The grids for each dimension.
+
+    Returns
+    -------
+    np.ndarray
+        The denominators of the interpolation weights.
+    """
+    denoms = np.ones(inds.shape[1], dtype=np.float64)
+    for i, g in enumerate(grids):
+        d = np.diff(g)
+        denoms *= d[inds[i, :]]
+    return denoms
+
+
+@njit
+def get_combinations(ndim: int) -> np.ndarray:
+    """
+    Produces an array with all the 2**ndim possible combinations of 0s and 1s.
+    This is used later to generate all the possible combinations of backward and forward differences.
+
+    Parameters
+    ----------
+    ndim : int
+        The number of dimensions.
+
+    Returns
+    -------
+    np.ndarray
+        An array with all the 2**ndim possible combinations of 0s and 1s.
+    """
+    bits = np.zeros((2**ndim, ndim), dtype=np.int64)
+    for i in range(ndim):
+        col = (ndim - 1) - i
+        for j in range(2**ndim):
+            bits[j, col] = (j >> i) & 1
+    return bits
+
+
+@njit
+def numerators(
+    diffs: np.ndarray, comb_inds: np.ndarray, ndims: int, npoints: int
+) -> np.ndarray:
+    """
+    Finds the numerators of the interpolation weights, which are the areas of the hypercubes
+    formed by the points and the grid points that contain them.
+
+    Parameters
+    ----------
+    diffs : np.ndarray
+        A (2, ndim, npoints) that contains the forward and backward differences of point coordinates.
+        and the grid points that contain them along every dimension.
+    comb_inds : np.ndarray
+        An array with all the 2**ndim possible combinations of 0s and 1s (fwd and bwd differences).
+    ndims : int
+        The number of dimensions.
+    npoints : int
+        The number of points.
+
+    Returns
+    -------
+    np.ndarray
+        The numerators of the interpolation weights.
+    """
+    numers = np.ones((2**ndims, npoints), dtype=np.float64)
+    for i in range(2**ndims):
+        for d, j in enumerate(comb_inds[i]):
+            numers[i, :] *= diffs[j, d, :]
+
+    return numers
+
+
+@njit
+def mass_to_grid(
+    points: np.ndarray, mass: np.ndarray, grids: List[np.ndarray]
+) -> np.ndarray:
+    """
+    Distributes the mass of a set of R^n points to a rectangular R^n grid,
+    following the 'lottery' method.
+
+    Parameters
+    ----------
+    points : np.ndarray
+        shape = (#points, #dims) The points to be distributed.
+    mass : np.ndarray
+        shape = (#points) The mass of each point.
+    grids : List[np.ndarray]
+        The grids for each dimension.
+
+    Returns
+    -------
+    np.ndarray
+        The mass of each point in the grid. (flattened).
+    """
+    dims = np.array([len(g) for g in grids])
+    ndims = len(grids)
+    npoints = points.shape[0]
+
+    # Trim points to maximum and minimum of grids
+    grid_inf_lims = np.expand_dims(np.array([x[0] for x in grids]), 0)
+    grid_sup_lims = np.expand_dims(np.array([x[-1] for x in grids]), 0)
+    points = np.clip(points, grid_inf_lims, grid_sup_lims)
+
+    # Find lower indices along every dimension
+    inds = multidim_get_lower_index(points, grids, dims).T
+
+    # Forward and backward differences
+    diffs = fwd_and_bwd_diffs(points, grids, inds)
+
+    # Matrix with combinations of forward and backward differencess
+    comb_inds = get_combinations(len(grids))
+
+    # Find denominators
+    numers = numerators(diffs, comb_inds, ndims, npoints)
+    denoms = denominators(inds, grids)
+
+    # Multiply the ndim differences to find areas
+    fact = mass / denoms
+
+    # Weights add up to 1
+    weights = numers * np.expand_dims(fact, 0)
+
+    # A (ndim, 2**ndim, npoints) matrix in which [:,:,n] nth row has
+    # the indices where we should add weights[:,n]
+    add_inds = np.expand_dims(inds, axis=1) + (1 - np.expand_dims(comb_inds.T, -1))
+
+    # Make indices unidimensional (to not do *inds in multidim matrices with numba)
+    add_inds = ravel_index(add_inds, dims)
+    distr = sum_weights(weights, dims, add_inds)
+
+    return distr

--- a/HARK/tests/test_mat_methods.py
+++ b/HARK/tests/test_mat_methods.py
@@ -1,0 +1,87 @@
+import unittest
+import numpy as np
+from HARK.utilities import jump_to_grid_1D, jump_to_grid_2D
+from HARK.mat_methods import mass_to_grid
+
+
+# Compare general mass_to_grid with jump_to_grid_1D
+class TestMassToGrid1D(unittest.TestCase):
+    def setUp(self):
+        n_grid = 30
+        n_points = 1000
+
+        # Create 1d grid
+        self.grid = np.linspace(0, 10.0, n_grid)
+        # Simulate 1d points from a normal distribution
+        # large variance to ensure some points are outside the grid
+        self.points = np.random.normal(5, 20, n_points)
+        # Create weights
+        self.weights = np.random.uniform(0, 1, n_points)
+
+    def test_compare_jump_to_grid_1d(self):
+        # Compare mass_to_grid with jump_to_grid_1D
+        res1 = mass_to_grid(self.points[..., np.newaxis], self.weights, (self.grid,))
+        res2 = jump_to_grid_1D(self.points, self.weights, self.grid)
+
+        # Compare results
+        self.assertTrue(np.allclose(res1, res2))
+
+
+# Compare general mass_to_grid with jump_to_grid_2D
+class TestMassToGrid2D(unittest.TestCase):
+    def setUp(self):
+        n_grid = 30
+        n_points = 1000
+
+        # Create 2d grid
+        self.x_grid = np.linspace(0.0, 10, n_grid)
+        self.y_grid = np.linspace(0.0, 10, n_grid)
+
+        # Simulate 2d points from a normal distribution
+        # large variance to ensure some points are outside the grid
+        mean = np.array([3, 4])
+        vcov = np.array([[10.0, -0.5], [-0.5, 3.0]])
+        self.points = np.random.multivariate_normal(mean, vcov, n_points)
+        self.weights = np.repeat(1.3, n_points)
+
+    def test_compare_jump_to_grid_2d(self):
+        # Compare mass_to_grid with jump_to_grid_2D
+        res1 = mass_to_grid(self.points, self.weights, (self.x_grid, self.y_grid))
+        res2 = jump_to_grid_2D(
+            self.points[:, 0], self.points[:, 1], self.weights, self.x_grid, self.y_grid
+        )
+
+        # Compare results
+        self.assertTrue(np.allclose(res1, res2))
+
+
+class Test3DMassToGrid(unittest.TestCase):
+    def test_simple_3d(self):
+        # 3d grid of 2 points in each dimension
+        x_grid = np.array([0.0, 1.0])
+        y_grid = np.array([0.0, 1.0])
+        z_grid = np.array([0.0, 1.0])
+
+        # Some points
+        my_points = np.array(
+            [
+                [0.5, 0.5, 0.5],
+                [3.0, 3.0, 3.0],
+            ]
+        )
+        mass = np.array([1.0, 1.0])
+
+        # Compare results
+        grid_mass = mass_to_grid(my_points, mass, (x_grid, y_grid, z_grid))
+
+        grid_mass = grid_mass.reshape((2, 2, 2))
+
+        # Check the mass on the 8 points
+        self.assertTrue(grid_mass[0, 0, 0] == 1 / 8)
+        self.assertTrue(grid_mass[0, 0, 1] == 1 / 8)
+        self.assertTrue(grid_mass[0, 1, 0] == 1 / 8)
+        self.assertTrue(grid_mass[0, 1, 1] == 1 / 8)
+        self.assertTrue(grid_mass[1, 0, 0] == 1 / 8)
+        self.assertTrue(grid_mass[1, 0, 1] == 1 / 8)
+        self.assertTrue(grid_mass[1, 1, 0] == 1 / 8)
+        self.assertTrue(grid_mass[1, 1, 1] == (1 / 8 + 1.0))


### PR DESCRIPTION
The transition-matrix way of doing things involves spreading the mass of simulated points to an exogenous grid of the state space. We currently can do this for 1D and 2D state spaces with the `jump_to_grid_1D` and `jump_to_grid_2D` methods. This PR adds a method called `mass_to_grid`, which achieves the same goal, but for ND state spaces.

It adds tests that verify that the output of the new function is the same as that of `jump_to_grid_1D` and `jump_to_grid_2D` . In my own tests, `mass_to_grid` is about ~2 times slower than the `jump_to_grid_1D` and `jump_to_grid_2D` methods. Still, I thought it would be good to have the general version around at least for testing higher-dimensional models. If performance ever becomes an issue we can try to make it faster, or code up `jump_to_grid_3D`. But as far as I understand, this part of the matrix-method algorithms is a tiny fraction of their total time so it does not look like the ~2 factor is a concern.

Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
