### PR TITLE
Fix typo in recently merged PR

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -15,7 +15,7 @@ Release Date: TBD
 ### Major Changes
 
 ### Minor Changes
-- Adds option `sim_common_Rriksy` to control whether risky-asset models draw common or idiosyncratic returns in simulation. [#1250](https://github.com/econ-ark/HARK/pull/1250)
+- Adds option `sim_common_Rrisky` to control whether risky-asset models draw common or idiosyncratic returns in simulation. [#1250](https://github.com/econ-ark/HARK/pull/1250),[#1253](https://github.com/econ-ark/HARK/pull/1253)
 
 ### 0.13.0
 

--- a/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
@@ -63,8 +63,8 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
 
         # Boolean determines whether, when simulating a given time period,
         # all agents will draw the same risky return factor (true by default)
-        if not hasattr(self, "sim_common_Rriksy"):
-            self.sim_common_Rriksy = True
+        if not hasattr(self, "sim_common_Rrisky"):
+            self.sim_common_Rrisky = True
 
         # Initialize a basic consumer type
         IndShockConsumerType.__init__(self, verbose=verbose, quiet=quiet, **kwds)
@@ -325,7 +325,7 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
             RiskyStd = self.RiskyStd
 
         # Draw either a common economy-wide return, or one for each agent
-        if self.sim_common_Rriksy:
+        if self.sim_common_Rrisky:
             self.shocks["Risky"] = Lognormal.from_mean_std(
                 RiskyAvg, RiskyStd, seed=self.RNG.integers(0, 2**31 - 1)
             ).draw(1)
@@ -1318,7 +1318,7 @@ risky_asset_parms = {
     "AdjustPrb": 1.0,
     # When simulating the model, should all agents get the same risky return in
     # a given period?
-    "sim_common_Rriksy": True,
+    "sim_common_Rrisky": True,
 }
 
 # Make a dictionary to specify a risky asset consumer type

--- a/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
@@ -245,7 +245,7 @@ class testRiskyReturnDim(PortfolioConsumerTypeTestCase):
             )
         )
         # Agent specific simulation
-        self.pcct.sim_common_Rriksy = False
+        self.pcct.sim_common_Rrisky = False
         self.pcct.initialize_sim()
         self.pcct.simulate()
         # Assety that all columns of Risky are not the same


### PR DESCRIPTION
The PR with idiosyncratic risky return draws (https://github.com/econ-ark/HARK/pull/1250) had a typo: `riksy` instead of `risky`.

This PR fixes the typo

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
