### PR TITLE
Skip CI for documentation-only PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - ".github/workflows/documentation.yml"
+      - "Documentation/**"
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - ".github/workflows/documentation.yml"
+      - "Documentation/**"
 
 jobs:
   build:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - ".github/workflows/documentation.yml"
+      - "Documentation/**"
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - ".github/workflows/documentation.yml"
+      - "Documentation/**"
   schedule:
     - cron: 0 0 * * *
 

--- a/.github/workflows/hark.yml
+++ b/.github/workflows/hark.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - ".github/workflows/documentation.yml"
+      - "Documentation/**"
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - ".github/workflows/documentation.yml"
+      - "Documentation/**"
 
 jobs:
   build:


### PR DESCRIPTION
The main CI takes a long time; skip it for documentation-only changes.

A