### PR TITLE
Cache PyPI packages in the documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,6 +32,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.9"  # Numba doesn't support Python 3.11 [2023-05]
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements/base.txt
+          requirements/dev.txt
 
     - name: Install Pandoc
       run: sudo apt-get install --yes pandoc


### PR DESCRIPTION
This should speed up the CI by performing fewer downloads on each CI run.

A