### PR TITLE
Remove transition from the end of ``Installation_instruction.md``

### DIFF
--- a/Documentation/contributing/Installation_instruction.md
+++ b/Documentation/contributing/Installation_instruction.md
@@ -215,5 +215,3 @@ If for some reason you want to switch back to the PyPI version:
 pip uninstall econ-ark
 pip install econ-ark (options)
 ```
-
----


### PR DESCRIPTION
This fixes a syntax error in the parser: ``Documentation\contributing\Installation_instruction.md:0: ERROR: Document may not end with a transition.``

A