### PR TITLE
Adopt favicon

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -61,6 +61,8 @@ html_theme = "pydata_sphinx_theme"
 # Use Econ-ARK URL to host the website
 html_baseurl = "https://docs.econ-ark.org"
 
+html_favicon = "images/econ-ark-logo.png"
+
 # sphinx.ext.intersphinx configuration
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),


### PR DESCRIPTION
This PR sets the Econ-ARK logo to the favicon of the page in the documentation. A more ideal favicon might be the four lines isolated, maybe enlargened a bit, and put into a square aspect ratio -- but we mustn't let perfect be the enemy of the good!

  A
  
  cc: @MridulS 