### PR TITLE
Add a grid of links to the landing page

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,7 @@ jobs:
         cache: 'pip'
         cache-dependency-path: |
           requirements/base.txt
-          requirements/dev.txt
+          requirements/doc.txt
 
     - name: Install Pandoc
       run: sudo apt-get install --yes pandoc

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,7 +44,7 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install HARK
-      run: python -m pip install .[dev]
+      run: python -m pip install .[doc]
 
     - name: Run Sphinx
       run: >

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -20,6 +20,7 @@ version = release = "latest"
 
 # General configuration
 extensions = [
+    # built-in extensions
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
@@ -30,8 +31,11 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
+    # third-party extensions
     "nbsphinx",
     "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
 ]
 
 exclude_patterns = [

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -23,3 +23,87 @@ or are contributing to the core software.
 If you are a student trying to learn economics concepts,
 you might want to look at the `DemARK
 <https://github.com/econ-ark/DemARK/>`_ project.
+
+.. grid:: 2
+
+   .. grid-item-card::
+      :padding: 2
+      :text-align: center
+
+      **Quick-start guide**
+      ^^^^^^^^^^^^^^^^^^^^^
+
+      To get up-and-running with HARK, see the quick-start guide
+      for a brief overview
+      and guidance on further resources.
+
+      +++
+
+      .. button-ref:: guides/quick_start
+         :ref-type: doc
+         :color: info
+         :click-parent:
+         :expand:
+
+         Quick Start Guide
+
+   .. grid-item-card::
+      :padding: 2
+      :text-align: center
+
+      **API reference**
+      ^^^^^^^^^^^^^^^^^
+
+      The reference guide contains a detailed description of the HARK API,
+      and assumes an understanding of HARK's key concepts.
+
+      +++
+
+      .. button-ref:: reference/index
+         :ref-type: doc
+         :color: info
+         :click-parent:
+         :expand:
+
+         Tools & Models Reference Guide
+
+   .. grid-item-card::
+      :padding: 2
+      :text-align: center
+
+      **ARKitecture**
+      ^^^^^^^^^^^^^^^
+
+      For a high-level overview of Econ-ARK's structure and design, see the ARKitecture.
+
+      +++
+
+      .. button-ref:: overview/ARKitecture
+         :ref-type: doc
+         :color: info
+         :click-parent:
+         :expand:
+
+         The ARKitecture
+
+   .. grid-item-card::
+      :padding: 2
+      :text-align: center
+
+      **Developer's guide**
+      ^^^^^^^^^^^^^^^^^^^^^
+
+      Saw a typo in the documentation?
+      Want to improve existing functionalities?
+      The contributing guidelines will guide you through
+      the process of improving Econ-ARK.
+
+      +++
+
+      .. button-ref:: guides/contributing
+         :ref-type: doc
+         :color: info
+         :click-parent:
+         :expand:
+
+         Contributing Guide

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -10,6 +10,11 @@ Econ-ARK documentation -- HARK
    Guides <guides/index>
 
 
+**Useful links**:
+:doc:`Install HARK <guides/installation>` |
+`Source Repository <https://github.com/Econ-ARK/HARK>`__ |
+`Issues & Ideas <https://github.com/Econ-ARK/HARK/issues>`__
+
 **HARK**, the *Heterogenous Agents Resources & toolKit*,
 is a toolkit for the structural modeling of economic choices
 of optimizing and non-optimizing heterogeneous agents.

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -10,7 +10,7 @@ Econ-ARK documentation -- HARK
    Guides <guides/index>
 
 
-Heterogenous Agents Resources & toolKit (HARK)
+**HARK**, the *Heterogenous Agents Resources & toolKit*,
 is a toolkit for the structural modeling of economic choices
 of optimizing and non-optimizing heterogeneous agents.
 
@@ -20,7 +20,7 @@ It is aimed at computational researchers and other
 software developers who are building new models with HARK,
 or are contributing to the core software.
 
-If you are a student trying to learn economics concepts,
+If you are a student trying to learn economic concepts,
 you might want to look at the `DemARK
 <https://github.com/econ-ark/DemARK/>`_ project.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dynamic = ["dependencies", "optional-dependencies"]
 file = "requirements/base.txt"
 
 [tool.setuptools.dynamic.optional-dependencies]
-dev = {"file" = "requirements/dev.txt"}
+dev.file = "requirements/dev.txt"
+doc.file = "requirements/doc.txt"
 
 [project.urls]
 Homepage = "https://github.com/econ-ark/HARK"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,9 +1,5 @@
 estimagic
-nbsphinx>=0.8
 nbval
 pre-commit
 pytest
 pytest-xdist
-myst-parser>=2
-sphinx>=6.1
-pydata-sphinx-theme

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,7 @@ sphinx>=6.1
 pydata-sphinx-theme
 
 # extension requirements
+ipython  # for the Pygments lexer
 myst-parser>=2
 nbsphinx>=0.8
 sphinx-copybutton

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,0 +1,10 @@
+sphinx>=6.1
+
+# theme requirements
+pydata-sphinx-theme
+
+# extension requirements
+myst-parser>=2
+nbsphinx>=0.8
+sphinx-copybutton
+sphinx-design


### PR DESCRIPTION
cc: @MridulS @DominicWC

This PR is on top of #1313, and adds a landing-page grid of links, similar to SciPy, NumPy, MatPlotLib, et al.

Open to suggestions about the order and content of the four boxes, I've chosen what I think is a sensible starting point.

A