### PR TITLE
Use Python 3.10 in the documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"  # Numba doesn't support Python 3.11 [2023-05]
+        python-version: "3.10"  # Interpolation.py doesn't support Python 3.11 [2023-07]
         cache: 'pip'
         cache-dependency-path: |
           requirements/base.txt


### PR DESCRIPTION
cc: @MridulS

Given ``numba`` now supports Python 3.11 I tried to increase all the way, but ``interpolation`` has an upper-limit on Python 3.10 -- see https://github.com/EconForge/interpolation.py/issues/103 and https://github.com/EconForge/interpolation.py/pull/105.

A