### PR TITLE
Execute notebooks on rendering documentation [DO-NOT-MERGE]

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -126,4 +126,4 @@ autosummary_generate = True
 napoleon_use_ivar = True  # solves duplicate object description warning
 
 # nbsphinx configuration
-nbsphinx_execute = "never"  # This is currently not working
+nbsphinx_execute = "always"

--- a/Documentation/example_notebooks/LifecycleModel.ipynb
+++ b/Documentation/example_notebooks/LifecycleModel.ipynb
@@ -1,1 +1,0 @@
-../../examples/LifecycleModel/LifecycleModel.ipynb

--- a/Documentation/overview/index.rst
+++ b/Documentation/overview/index.rst
@@ -18,7 +18,6 @@ Overview
    ../example_notebooks/KinkedRconsumerType.ipynb
    ../example_notebooks/ConsPortfolioModel.ipynb
    ../example_notebooks/GenIncProcessModel.ipynb
-   ../example_notebooks/LifecycleModel.ipynb
    ../example_notebooks/HowWeSolveIndShockConsumerType.ipynb
    ../example_notebooks/Journey-PhD.ipynb
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,3 +9,6 @@ myst-parser>=2
 nbsphinx>=0.8
 sphinx-copybutton
 sphinx-design
+
+# notebook requirements
+ipykernel


### PR DESCRIPTION
cc: @MridulS

Opened for discussion, as currently the PR doesn't work for all notebooks (``import EstimationParameters as Params`` fails in the life cycle model).

Would this be useful? It has the benefit of ensuring that the content in the notebook renders and is accurate, but significantly slows down the rendering of the documentation.

A