### PR TITLE
Add ``sphinx-lint`` checks to CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -73,3 +73,24 @@ jobs:
         --force 
         https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}
         `git subtree split --prefix HARK-docs/html gh-pages`:refs/heads/gh-pages
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade sphinx-lint
+    - name: Lint documentation with sphinx-lint
+      run: >
+        sphinx-lint
+        --enable line-too-long
+        --max-line-length 85 
+        README.md
+        Documentation/

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Lint documentation with sphinx-lint
       run: >
         sphinx-lint
-        --ignore Documentation\example_notebooks\GenIncProcessModel.py
+        --ignore Documentation/example_notebooks/GenIncProcessModel.py
         --enable all
         --max-line-length 85 
         README.md

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -90,7 +90,8 @@ jobs:
     - name: Lint documentation with sphinx-lint
       run: >
         sphinx-lint
-        --enable line-too-long
+        --ignore Documentation\example_notebooks\GenIncProcessModel.py
+        --enable all
         --max-line-length 85 
         README.md
         Documentation/


### PR DESCRIPTION
cc: @MridulS

This adds automatic linting checks to the documentation, to run on every PR.

Due to the symlink, ``GenIncProcessModel`` needs to be excluded for now.

A