### PR TITLE
Let `ConsRiskyAssetModel` handle time-varying Rfree

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -22,6 +22,7 @@ Release Date: TBD
 - Addresses [#1255](https://github.com/econ-ark/HARK/issues/1255). Makes age-varying stochastic returns possible and draws from their discretized version. [#1262](https://github.com/econ-ark/HARK/pull/1262)
 - Fixes bug in the metric that compares dictionaries with the same keys. [#1260](https://github.com/econ-ark/HARK/pull/1260)
 - Fixes bug in the calc_jacobian method. [#1342](https://github.com/econ-ark/HARK/pull/1342)
+- Fixes bug that prevented risky-asset consumer types from working with time-varying interest rates `Rfree`. [1343](https://github.com/econ-ark/HARK/pull/1343)
 ### 0.13.0
 
 Release Date: February, 16, 2023

--- a/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
@@ -237,15 +237,21 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
         -------
         None
         """
-        if "RiskyDstn" in self.time_vary:
+        if "RiskyDstn" in self.time_vary or "Rfree" in self.time_vary:
             self.ShareLimit = []
             for t in range(self.T_cycle):
-                RiskyDstn = self.RiskyDstn[t]
+                if "RiskyDstn" in self.time_vary:
+                    RiskyDstn = self.RiskyDstn[t]
+                else:
+                    RiskyDstn = self.RiskyDstn
+                if "Rfree" in self.time_vary:
+                    Rfree = self.Rfree[t]
+                else:
+                    Rfree = self.Rfree
 
                 def temp_f(s):
                     return -((1.0 - self.CRRA) ** -1) * np.dot(
-                        (self.Rfree + s * (RiskyDstn.atoms - self.Rfree))
-                        ** (1.0 - self.CRRA),
+                        (Rfree + s * (RiskyDstn.atoms - Rfree)) ** (1.0 - self.CRRA),
                         RiskyDstn.pmv,
                     )
 
@@ -334,7 +340,9 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
             else:
                 # Make use of the IndexDistribution.draw() method
                 self.shocks["Risky"] = self.RiskyDstn.draw(
-                    np.maximum(self.t_cycle - 1,0) if self.cycles == 1 else self.t_cycle
+                    np.maximum(self.t_cycle - 1, 0)
+                    if self.cycles == 1
+                    else self.t_cycle
                 )
 
         else:
@@ -360,7 +368,7 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
         """
         if "AdjustPrb" in self.time_vary:
             self.shocks["Adjust"] = self.AdjustDstn.draw(
-                 np.maximum(self.t_cycle - 1,0) if self.cycles == 1 else self.t_cycle
+                np.maximum(self.t_cycle - 1, 0) if self.cycles == 1 else self.t_cycle
             )
         else:
             self.shocks["Adjust"] = self.AdjustDstn.draw(self.AgentCount)

--- a/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsPortfolioModel.py
@@ -257,7 +257,7 @@ class testRiskyReturnDim(PortfolioConsumerTypeTestCase):
         )
 
 
-class test_time_varying_Risky_and_Adj(unittest.TestCase):
+class test_time_varying_Risky_Rfree_and_Adj(unittest.TestCase):
     def setUp(self):
         # Create a parameter dictionary for a three period problem
         self.params = cpm.init_portfolio.copy()
@@ -267,7 +267,7 @@ class test_time_varying_Risky_and_Adj(unittest.TestCase):
                 "cycles": 1,
                 "T_cycle": 3,
                 "T_age": 3,
-                "Rfree": 1.0,
+                "Rfree": [1.0, 0.99, 0.98],
                 "RiskyAvg": [1.01, 1.02, 1.03],
                 "RiskyStd": [0.0, 0.0, 0.0],
                 "RiskyCount": 1,


### PR DESCRIPTION
I was getting errors trying to get `ConsPortfolio` to use time varying interest rates `Rfree`.

The culprit was that the share-limit calculation assumed `Rfree` is constant. This PR fixes the issue.

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
