### PR TITLE
Replace \texttt{} in notebooks

### DIFF
--- a/examples/ConsIndShockModel/PerfForesightConsumerType.ipynb
+++ b/examples/ConsIndShockModel/PerfForesightConsumerType.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Perfect foresight consumption-saving\n",
     "\n",
-    "**The `PerfForesightConsumerType` class**"
+    "**The** `PerfForesightConsumerType` **class**"
    ]
   },
   {
@@ -113,15 +113,15 @@
     "\n",
     "| Parameter | Description | Code | Example value | Time-varying? |\n",
     "| :---: | --- | --- | --- | --- |\n",
-    "| $\\DiscFac$ |Intertemporal discount factor  | $\\texttt{DiscFac}$ | $0.96$ |  |\n",
-    "| $\\CRRA$ |Coefficient of relative risk aversion | $\\texttt{CRRA}$ | $2.0$ | |\n",
-    "| $\\Rfree$ | Risk free interest factor | $\\texttt{Rfree}$ | $1.03$ | |\n",
-    "| $1 - \\DiePrb_{t+1}$ |Survival probability | $\\texttt{LivPrb}$ | $[0.98]$ | $\\surd$ |\n",
-    "|$\\PermGroFac_{t+1}$|Permanent income growth factor|$\\texttt{PermGroFac}$| $[1.01]$ | $\\surd$ |\n",
-    "|$\\underline{a}$|Artificial borrowing constraint|$\\texttt{BoroCnstArt}$| $None$ |  |\n",
-    "|$(none)$|Maximum number of gridpoints in consumption function |$\\texttt{aXtraCount}$| $200$ |  |\n",
-    "|$T$| Number of periods in this type's \"cycle\" |$\\texttt{T\\_cycle}$| $1$ | |\n",
-    "|(none)| Number of times the \"cycle\" occurs |$\\texttt{cycles}$| $0$ | |\n",
+    "| $\\DiscFac$ |Intertemporal discount factor  | `DiscFac` | $0.96$ |  |\n",
+    "| $\\CRRA$ |Coefficient of relative risk aversion | `CRRA` | $2.0$ | |\n",
+    "| $\\Rfree$ | Risk free interest factor | `Rfree` | $1.03$ | |\n",
+    "| $1 - \\DiePrb_{t+1}$ |Survival probability | `LivPrb` | $[0.98]$ | $\\surd$ |\n",
+    "|$\\PermGroFac_{t+1}$|Permanent income growth factor|`PermGroFac`| $[1.01]$ | $\\surd$ |\n",
+    "|$\\underline{a}$|Artificial borrowing constraint|`BoroCnstArt`| $None$ |  |\n",
+    "|$(none)$|Maximum number of gridpoints in consumption function |`aXtraCount`| $200$ |  |\n",
+    "|$T$| Number of periods in this type's \"cycle\" |`T_cycle`| $1$ | |\n",
+    "|(none)| Number of times the \"cycle\" occurs |`cycles`| $0$ | |\n",
     "\n",
     "Note that the survival probability and income growth factor have time subscripts; likewise, the example values for these parameters are *lists* rather than simply single floats.  This is because those parameters are *time-varying*: their values can depend on which period of the problem the agent is in.  All time-varying parameters *must* be specified as lists, even if the same value occurs in each period for this type.\n",
     "\n",
@@ -129,9 +129,9 @@
     "\n",
     "The last two parameters in the table specify the \"nature of time\" for this type: the number of (non-terminal) periods in this type's \"cycle\", and the number of times that the \"cycle\" occurs.  *Every* subclass of `AgentType` uses these two code parameters to define the nature of time.  Here, `T_cycle` has the value $1$, indicating that there is exactly one period in the cycle, while `cycles` is $0$, indicating that the cycle is repeated in *infinite* number of times-- it is an infinite horizon model, with the same \"kind\" of period repeated over and over.\n",
     "\n",
-    "In contrast, we could instead specify a life-cycle model by setting `T_cycle` to $1$, and specifying age-varying sequences of income growth and survival probability.  In all cases, the number of elements in each time-varying parameter should exactly equal $\\texttt{T\\_cycle}$.\n",
+    "In contrast, we could instead specify a life-cycle model by setting `T_cycle` to $1$, and specifying age-varying sequences of income growth and survival probability.  In all cases, the number of elements in each time-varying parameter should exactly equal `T_cycle`.\n",
     "\n",
-    "The parameter $\\texttt{AgentCount}$ specifies how many consumers there are of this *type*-- how many individuals have these exact parameter values and are *ex ante* homogeneous.  This information is not relevant for solving the model, but is needed in order to simulate a population of agents, introducing *ex post* heterogeneity through idiosyncratic shocks.  Of course, simulating a perfect foresight model is quite boring, as there are *no* idiosyncratic shocks other than death!\n",
+    "The parameter `AgentCount` specifies how many consumers there are of this *type*-- how many individuals have these exact parameter values and are *ex ante* homogeneous.  This information is not relevant for solving the model, but is needed in order to simulate a population of agents, introducing *ex post* heterogeneity through idiosyncratic shocks.  Of course, simulating a perfect foresight model is quite boring, as there are *no* idiosyncratic shocks other than death!\n",
     "\n",
     "The cell below defines a dictionary that can be passed to the constructor method for `PerfForesightConsumerType`, with the values from the table here."
    ]
@@ -183,7 +183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The $\\texttt{solve}$ method fills in the instance's attribute `solution` as a time-varying list of solutions to each period of the consumer's problem.  In this case, `solution` will be a list with exactly one instance of the class `ConsumerSolution`, representing the solution to the infinite horizon model we specified."
+    "The `solve` method fills in the instance's attribute `solution` as a time-varying list of solutions to each period of the consumer's problem.  In this case, `solution` will be a list with exactly one instance of the class `ConsumerSolution`, representing the solution to the infinite horizon model we specified."
    ]
   },
   {
@@ -207,9 +207,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each element of `solution` has a few attributes. To see all of them, we can use the $\\texttt{vars}$ built in function:\n",
+    "Each element of `solution` has a few attributes. To see all of them, we can use the `vars` built in function:\n",
     "\n",
-    "the consumption functions reside in the attribute $\\texttt{cFunc}$ of each element of `ConsumerType.solution`.  This method creates a (time varying) attribute $\\texttt{cFunc}$ that contains a list of consumption functions."
+    "the consumption functions reside in the attribute `cFunc` of each element of `ConsumerType.solution`.  This method creates a (time varying) attribute `cFunc` that contains a list of consumption functions."
    ]
   },
   {
@@ -233,7 +233,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The two most important attributes of a single period solution of this model are the (normalized) consumption function $\\texttt{cFunc}$ and the (normalized) value function $\\texttt{vFunc}$.  Let's plot those functions near the lower bound of the permissible state space (the attribute $\\texttt{mNrmMin}$ tells us the lower bound of $m_t$ where the consumption function is defined)."
+    "The two most important attributes of a single period solution of this model are the (normalized) consumption function `cFunc` and the (normalized) value function `vFunc`.  Let's plot those functions near the lower bound of the permissible state space (the attribute `mNrmMin` tells us the lower bound of $m_t$ where the consumption function is defined)."
    ]
   },
   {
@@ -297,11 +297,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An element of `solution` also includes the (normalized) marginal value function $\\texttt{vPfunc}$, and the lower and upper bounds of the marginal propensity to consume (MPC) $\\texttt{MPCmin}$ and $\\texttt{MPCmax}$.  Note that with a linear consumption function, the MPC is constant, so its lower and upper bound are identical.\n",
+    "An element of `solution` also includes the (normalized) marginal value function `vPfunc`, and the lower and upper bounds of the marginal propensity to consume (MPC) `MPCmin` and `MPCmax`.  Note that with a linear consumption function, the MPC is constant, so its lower and upper bound are identical.\n",
     "\n",
     "### Liquidity constrained perfect foresight example\n",
     "\n",
-    "Without an artificial borrowing constraint, a perfect foresight consumer is free to borrow against the PDV of his entire future stream of labor income-- his \"human wealth\" $\\texttt{hNrm}$-- and he will consume a constant proportion of his total wealth (market resources plus human wealth).  If we introduce an artificial borrowing constraint, both of these features vanish.  In the cell below, we define a parameter dictionary that prevents the consumer from borrowing *at all*, create and solve a new instance of `PerfForesightConsumerType` with it, and then plot its consumption function."
+    "Without an artificial borrowing constraint, a perfect foresight consumer is free to borrow against the PDV of his entire future stream of labor income -- his \"human wealth\" `hNrm` -- and he will consume a constant proportion of his total wealth (market resources plus human wealth).  If we introduce an artificial borrowing constraint, both of these features vanish.  In the cell below, we define a parameter dictionary that prevents the consumer from borrowing *at all*, create and solve a new instance of `PerfForesightConsumerType` with it, and then plot its consumption function."
    ]
   },
   {
@@ -349,7 +349,7 @@
     "incorrectly_encoded_metadata": "pycharm= [markdown] {\"name\": \"#%% md\\n\"}"
    },
    "source": [
-    "At this time, the value function for a perfect foresight consumer with an artificial borrowing constraint is not computed nor included as part of its $\\texttt{solution}$."
+    "At this time, the value function for a perfect foresight consumer with an artificial borrowing constraint is not computed nor included as part of its `solution`."
    ]
   },
   {
@@ -366,20 +366,20 @@
     "\n",
     "| Description | Code | Example value |\n",
     "| :---: | --- | --- |\n",
-    "| Number of consumers of this type | $\\texttt{AgentCount}$ | $10000$ |\n",
-    "| Number of periods to simulate | $\\texttt{T\\_sim}$ | $120$ |\n",
-    "| Mean of initial log (normalized) assets | $\\texttt{aNrmInitMean}$ | $-6.0$ |\n",
-    "| Stdev of initial log  (normalized) assets | $\\texttt{aNrmInitStd}$ | $1.0$ |\n",
-    "| Mean of initial log permanent income | $\\texttt{pLvlInitMean}$ | $0.0$ |\n",
-    "| Stdev of initial log permanent income | $\\texttt{pLvlInitStd}$ | $0.0$ |\n",
-    "| Aggregrate productivity growth factor | $\\texttt{PermGroFacAgg}$ | $1.0$ |\n",
-    "| Age after which consumers are automatically killed | $\\texttt{T\\_age}$ | $None$ |\n",
+    "| Number of consumers of this type | `AgentCount` | $10000$ |\n",
+    "| Number of periods to simulate | `T_sim` | $120$ |\n",
+    "| Mean of initial log (normalized) assets | `aNrmInitMean` | $-6.0$ |\n",
+    "| Stdev of initial log  (normalized) assets | `aNrmInitStd` | $1.0$ |\n",
+    "| Mean of initial log permanent income | `pLvlInitMean` | $0.0$ |\n",
+    "| Stdev of initial log permanent income | `pLvlInitStd` | $0.0$ |\n",
+    "| Aggregrate productivity growth factor | `PermGroFacAgg` | $1.0$ |\n",
+    "| Age after which consumers are automatically killed | `T_age` | $None$ |\n",
     "\n",
     "We have specified the model so that initial assets and permanent income are both distributed lognormally, with mean and standard deviation of the underlying normal distributions provided by the user.\n",
     "\n",
-    "The parameter $\\texttt{PermGroFacAgg}$ exists for compatibility with more advanced models that employ aggregate productivity shocks; it can simply be set to 1.\n",
+    "The parameter `PermGroFacAgg` exists for compatibility with more advanced models that employ aggregate productivity shocks; it can simply be set to 1.\n",
     "\n",
-    "In infinite horizon models, it might be useful to prevent agents from living extraordinarily long lives through a fortuitous sequence of mortality shocks.  We have thus provided the option of setting $\\texttt{T\\_age}$ to specify the maximum number of periods that a consumer can live before they are automatically killed (and replaced with a new consumer with initial state drawn from the specified distributions).  This can be turned off by setting it to `None`.\n",
+    "In infinite horizon models, it might be useful to prevent agents from living extraordinarily long lives through a fortuitous sequence of mortality shocks.  We have thus provided the option of setting `T_age` to specify the maximum number of periods that a consumer can live before they are automatically killed (and replaced with a new consumer with initial state drawn from the specified distributions).  This can be turned off by setting it to `None`.\n",
     "\n",
     "The cell below puts these parameters into a dictionary, then gives them to `PFexample`.  Note that all of these parameters *could* have been passed as part of the original dictionary; we omitted them above for simplicity."
    ]
@@ -416,11 +416,11 @@
    "source": [
     "To generate simulated data, we need to specify which variables we want to track the \"history\" of for this instance.  To do so, we set the `track_vars` attribute of our `PerfForesightConsumerType` instance to be a list of strings with the simulation variables we want to track.\n",
     "\n",
-    "In this model, valid arguments to `track_vars` include $\\texttt{mNrm}$, $\\texttt{cNrm}$, $\\texttt{aNrm}$, and $\\texttt{pLvl}$.  Because this model has no idiosyncratic shocks, our simulated data will be quite boring.\n",
+    "In this model, valid arguments to `track_vars` include `mNrm`, `cNrm`, `aNrm`, and `pLvl`.  Because this model has no idiosyncratic shocks, our simulated data will be quite boring.\n",
     "\n",
     "### Generating simulated data\n",
     "\n",
-    "Before simulating, the `initialize_sim` method must be invoked.  This resets our instance back to its initial state, drawing a set of initial $\\texttt{aNrm}$ and $\\texttt{pLvl}$ values from the specified distributions and storing them in the attributes $\\texttt{aNrmNow\\_init}$ and $\\texttt{pLvlNow\\_init}$.  It also resets this instance's internal random number generator, so that the same initial states will be set every time `initialize_sim` is called.  In models with non-trivial shocks, this also ensures that the same sequence of shocks will be generated on every simulation run.\n",
+    "Before simulating, the `initialize_sim` method must be invoked.  This resets our instance back to its initial state, drawing a set of initial `aNrm` and `pLvl` values from the specified distributions and storing them in the attributes `aNrmNow_init` and `pLvlNow_init`.  It also resets this instance's internal random number generator, so that the same initial states will be set every time `initialize_sim` is called.  In models with non-trivial shocks, this also ensures that the same sequence of shocks will be generated on every simulation run.\n",
     "\n",
     "Finally, the `simulate` method can be called."
    ]
@@ -469,7 +469,7 @@
     "incorrectly_encoded_metadata": "pycharm= [markdown] {\"name\": \"#%% md\\n\"}"
    },
    "source": [
-    "Each simulation variable $\\texttt{X}$ named in $\\texttt{track\\_vars}$ will have the *history* of that variable for each agent stored in the attribute $\\texttt{X\\_hist}$ as an array of shape $(\\texttt{T\\_sim},\\texttt{AgentCount})$.  To see that the simulation worked as intended, we can plot the mean of $m_t$ in each simulated period:"
+    "Each simulation variable `X` named in `track_vars` will have the *history* of that variable for each agent stored in the attribute `X_hist` as an array of shape `(T_sim, AgentCount)`.  To see that the simulation worked as intended, we can plot the mean of $m_t$ in each simulated period:"
    ]
   },
   {
@@ -507,7 +507,7 @@
    "source": [
     "A perfect foresight consumer can borrow against the PDV of his future income -- his human wealth -- and thus as time goes on, our simulated agents approach the (very negative) steady state level of $m_t$ while being steadily replaced with consumers with roughly $m_t=1$.\n",
     "\n",
-    "The slight wiggles in the plotted curve are due to consumers randomly dying and being replaced; their replacement will have an initial state drawn from the distributions specified by the user.  To see the current distribution of ages, we can look at the attribute $\\texttt{t\\_age}$."
+    "The slight wiggles in the plotted curve are due to consumers randomly dying and being replaced; their replacement will have an initial state drawn from the distributions specified by the user.  To see the current distribution of ages, we can look at the attribute `t_age`."
    ]
   },
   {
@@ -549,11 +549,11 @@
     "\n",
     "One might wonder why HARK requires users to call `initialize_sim` before calling `simulate`: Why doesn't `simulate` just call `initialize_sim` as its first step?  We have broken up these two steps so that users can simulate some number of periods, change something in the environment, and then resume the simulation.\n",
     "\n",
-    "When called with no argument, `simulate` will simulate the model for $\\texttt{T\\_sim}$ periods.  The user can optionally pass an integer specifying the number of periods to simulate (which should not exceed $\\texttt{T\\_sim}$).\n",
+    "When called with no argument, `simulate` will simulate the model for `T_sim` periods.  The user can optionally pass an integer specifying the number of periods to simulate (which should not exceed `T_sim`).\n",
     "\n",
     "In the cell below, we simulate our perfect foresight consumers for 80 periods, then seize a bunch of their assets (dragging their wealth even more negative), then simulate for the remaining 40 periods.\n",
     "\n",
-    "The `state_prev` attribute of an AgenType stores the values of the model's state variables in the _previous_ period of the simulation."
+    "The `state_prev` attribute of an `AgentType` stores the values of the model's state variables in the _previous_ period of the simulation."
    ]
   },
   {


### PR DESCRIPTION
- Replaced the `\texttt{}` LaTeX environment with standard markdown code in the perfect foresight notebook

CC: @llorracc @alanlujan91