### PR TITLE
generate random seeds for IndexDistribution upon creation of income d…

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -29,6 +29,7 @@ Release Date: TBD
 - Creates a `models/` directory with Python model configurations for perfect foresight and Fisher 2-period models. [1347](https://github.com/econ-ark/HARK/pull/1347)
 - Fixes bug in AgentType simulations where 'who_dies' for period t was being recorded in period t-1in the history Carlo simulation functions using Python model configurations.[1296](https://github.com/econ-ark/HARK/pull/1296)
 - Removes unused `simulation.py` .[1296](https://github.com/econ-ark/HARK/pull/1296)
+- Fixes bug that default seed was being used in the initializing of income shock distributions. [1380](https://github.com/econ-ark/HARK/pull/1380)
 
 ### 0.13.0
 

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -3742,6 +3742,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 "IncUnemp": IncUnemp_list,
             },
             RNG=self.RNG,
+            seed=self.RNG.integers(0, 2**31 - 1)
         )
 
         PermShkDstn = IndexDistribution(
@@ -3751,6 +3752,8 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 "n_approx": PermShkCount_list,
                 "neutral_measure": neutral_measure_list,
             },
+            RNG=self.RNG,
+            seed=self.RNG.integers(0, 2**31 - 1)
         )
 
         TranShkDstn = IndexDistribution(
@@ -3761,6 +3764,9 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 "IncUnemp": IncUnemp_list,
                 "n_approx": TranShkCount_list,
             },
+            RNG=self.RNG,
+            seed=self.RNG.integers(0, 2**31 - 1)
+
         )
 
         return IncShkDstn, PermShkDstn, TranShkDstn

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -3742,7 +3742,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 "IncUnemp": IncUnemp_list,
             },
             RNG=self.RNG,
-            seed=self.RNG.integers(0, 2**31 - 1)
+            seed=self.RNG.integers(0, 2**31 - 1),
         )
 
         PermShkDstn = IndexDistribution(
@@ -3753,7 +3753,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 "neutral_measure": neutral_measure_list,
             },
             RNG=self.RNG,
-            seed=self.RNG.integers(0, 2**31 - 1)
+            seed=self.RNG.integers(0, 2**31 - 1),
         )
 
         TranShkDstn = IndexDistribution(
@@ -3765,8 +3765,7 @@ class IndShockConsumerType(PerfForesightConsumerType):
                 "n_approx": TranShkCount_list,
             },
             RNG=self.RNG,
-            seed=self.RNG.integers(0, 2**31 - 1)
-
+            seed=self.RNG.integers(0, 2**31 - 1),
         )
 
         return IncShkDstn, PermShkDstn, TranShkDstn

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -115,6 +115,12 @@ class testIndShockConsumerType(unittest.TestCase):
         # simulation test -- seed/generator specific
         # self.assertAlmostEqual(self.agent.state_now["aLvl"][1], 0.18438, place = HARK_PRECISION)
 
+    def test_income_dist_random_seeds(self):
+        a1 = IndShockConsumerType(seed = 1000)
+        a2 = IndShockConsumerType(seed = 200)
+
+        self.assertFalse(a1.PermShkDstn.seed == a2.PermShkDstn.seed)
+
 
 class testBufferStock(unittest.TestCase):
     """Tests of the results of the BufferStock REMARK."""
@@ -414,7 +420,7 @@ class testIndShockConsumerTypeCyclical(unittest.TestCase):
         CyclicalExample.simulate()
 
         self.assertAlmostEqual(
-            CyclicalExample.state_now["aLvl"][1], 2.41243, places=HARK_PRECISION
+            CyclicalExample.state_now["aLvl"][1], 3.32431, places=HARK_PRECISION
         )
 
 

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -116,8 +116,8 @@ class testIndShockConsumerType(unittest.TestCase):
         # self.assertAlmostEqual(self.agent.state_now["aLvl"][1], 0.18438, place = HARK_PRECISION)
 
     def test_income_dist_random_seeds(self):
-        a1 = IndShockConsumerType(seed = 1000)
-        a2 = IndShockConsumerType(seed = 200)
+        a1 = IndShockConsumerType(seed=1000)
+        a2 = IndShockConsumerType(seed=200)
 
         self.assertFalse(a1.PermShkDstn.seed == a2.PermShkDstn.seed)
 


### PR DESCRIPTION
fixes #1379 by generating random seeds from the AgentType's RNG when initializing the IndexDistributions for PermSfkDst and other distributions in `construct_lognormal_income_process_unemployment`

Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
