### PR TITLE
Remove metadata argument for jpg in make_figs

### DIFF
--- a/HARK/tests/test_HARKutilities.py
+++ b/HARK/tests/test_HARKutilities.py
@@ -3,9 +3,9 @@ This file implements unit tests to check HARK/utilities.py
 """
 # Bring in modules we need
 import unittest
-import matplotlib.pyplot as plt
 from types import SimpleNamespace
 
+import matplotlib.pyplot as plt
 import numpy as np
 
 from HARK.rewards import (
@@ -84,10 +84,10 @@ class testsForHARKutilities(unittest.TestCase):
         test = np.unique(np.diff(aXtraGrid).round(decimals=3))
 
         self.assertEqual(test.size, 1)
-        
+
     def test_make_figs(self):
         # Test the make_figs() function with a trivial output
         plt.figure()
-        plt.plot(np.linspace(1,5,40),np.linspace(4,8,40) )
-        make_figs('test', True , False, target_dir='')
+        plt.plot(np.linspace(1, 5, 40), np.linspace(4, 8, 40))
+        make_figs("test", True , False, target_dir="")
         plt.clf()

--- a/HARK/tests/test_HARKutilities.py
+++ b/HARK/tests/test_HARKutilities.py
@@ -3,6 +3,7 @@ This file implements unit tests to check HARK/utilities.py
 """
 # Bring in modules we need
 import unittest
+import matplotlib.pyplot as plt
 from types import SimpleNamespace
 
 import numpy as np
@@ -14,7 +15,7 @@ from HARK.rewards import (
     CRRAutilityPPP,
     CRRAutilityPPPP,
 )
-from HARK.utilities import construct_assets_grid
+from HARK.utilities import construct_assets_grid, make_figs
 
 
 class testsForHARKutilities(unittest.TestCase):
@@ -66,7 +67,7 @@ class testsForHARKutilities(unittest.TestCase):
         self.derivative_func_comparison(CRRAutilityPPPP, CRRAutilityPPP)
 
     def test_asset_grid(self):
-        # test linear asset grid
+        # Test linear asset grid
 
         params = {
             "aXtraMin": 0.0,
@@ -83,3 +84,10 @@ class testsForHARKutilities(unittest.TestCase):
         test = np.unique(np.diff(aXtraGrid).round(decimals=3))
 
         self.assertEqual(test.size, 1)
+        
+    def test_make_figs(self):
+        # Test the make_figs() function with a trivial output
+        plt.figure()
+        plt.plot(np.linspace(1,5,40),np.linspace(4,8,40) )
+        make_figs('test', True , False, target_dir='')
+        plt.clf()

--- a/HARK/tests/test_HARKutilities.py
+++ b/HARK/tests/test_HARKutilities.py
@@ -89,5 +89,5 @@ class testsForHARKutilities(unittest.TestCase):
         # Test the make_figs() function with a trivial output
         plt.figure()
         plt.plot(np.linspace(1, 5, 40), np.linspace(4, 8, 40))
-        make_figs("test", True , False, target_dir="")
+        make_figs("test", True, False, target_dir="")
         plt.clf()

--- a/HARK/utilities.py
+++ b/HARK/utilities.py
@@ -1006,7 +1006,7 @@ def make_figs(figure_name, saveFigs, drawFigs, target_dir="Figures"):
         print(f"Saving figure {figure_name} in {target_dir}")
         plt.savefig(
             os.path.join(target_dir, f"{figure_name}.jpg"),
-            #metadata={"CreationDate": None}, # metadata not supported for jpg
+            # metadata is not supported for jpg
         )  # For web/html
         plt.savefig(
             os.path.join(target_dir, f"{figure_name}.png"),

--- a/HARK/utilities.py
+++ b/HARK/utilities.py
@@ -1006,7 +1006,7 @@ def make_figs(figure_name, saveFigs, drawFigs, target_dir="Figures"):
         print(f"Saving figure {figure_name} in {target_dir}")
         plt.savefig(
             os.path.join(target_dir, f"{figure_name}.jpg"),
-            metadata={"CreationDate": None},
+            #metadata={"CreationDate": None}, # metadata not supported for jpg
         )  # For web/html
         plt.savefig(
             os.path.join(target_dir, f"{figure_name}.png"),


### PR DESCRIPTION
Metadata argument was not supported for this filetype, was throwing error. CDC wants a minor release for this. I'm going to put in one more annoying behavior fix before I do that.
