### PR TITLE
Allow for a pre-built grid in `LinearFast`

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -8,6 +8,16 @@ For more information on HARK, see [our Github organization](https://github.com/e
 
 ## Changes
 
+### 0.15.0
+
+Release Date: TBA
+
+### Major Changes
+
+### Minor Changes
+
+- Add option to pass pre-built grid to `LinearFast`. [1388](https://github.com/econ-ark/HARK/pull/1388)
+
 ### 0.14.0
 
 Release Date: February 12, 2024

--- a/HARK/econforgeinterp.py
+++ b/HARK/econforgeinterp.py
@@ -20,10 +20,10 @@ class LinearFast(MetricObject):
 
     distance_criteria = ["f_val", "grid_list"]
 
-    def __init__(self, f_val, grids, extrap_mode="linear"):
+    def __init__(self, f_val, grids, extrap_mode="linear", prebuilt_grid=None):
         """
         f_val: numpy.array
-            An array containing the values of the function at the grid points.
+        An array containing the values of the function at the grid points.
             It's i-th dimension must be of the same lenght as the i-th grid.
             f_val[i,j,k] must be f(grids[0][i], grids[1][j], grids[2][k]).
         grids: [numpy.array]
@@ -32,11 +32,17 @@ class LinearFast(MetricObject):
         extrap_mode: one of 'linear', 'nearest', or 'constant'
             Determines how to extrapolate, using either nearest point, multilinear, or
             constant extrapolation. The default is multilinear.
+        prebuilt_grid: CGrid, optional
+            A prebuilt CGrid object to be used as the grid. If None, a new one
+            will be created using the grids provided. By default None.
         """
         self.dim = len(grids)
         self.f_val = f_val
         self.grid_list = grids
-        self.Grid = CGrid(*grids)
+        if prebuilt_grid is None:
+            self.Grid = CGrid(*grids)
+        else:
+            self.Grid = prebuilt_grid
 
         # Set up extrapolation options
         self.extrap_mode = extrap_mode


### PR DESCRIPTION
The `CGrid` constructor of the econforge interpolation library can take a substantial time if you build many interpolators.

This PR allows you to pass a pre-constructed `CGrid` object to `LinearFast`.

This can save a lot of time in instances where you are building many interpolators over the same grid. For example, if you have consumption functions for many Markov states that are defined over the same asset grid. (cc: @wdu9 ?)

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
