### PR TITLE
Change repr to describe()

### DIFF
--- a/HARK/core.py
+++ b/HARK/core.py
@@ -323,7 +323,7 @@ class Model:
         s += ">"
         return s
 
-    def __repr__(self):
+    def describe(self):
         return self.__str__()
 
 


### PR DESCRIPTION
When the "parameters code" was added, it specified new behavior for `__repr__()`, listing *all* of the parameters whenever the object was returned to stdout. This is ok sometimes, but generates a massive amount of printed output in lifecycle models. Often the user just wants to do a quick check that an object is the class they think it is, or that there are the right number and kind of things in a list, and this behavior makes that impossible.

This commit *only* changes the function name `__repr__` to describe. I.e. the "list everything" behavior is still there, it just needs to be explicitly requested rather than assumed as the default.
