### PR TITLE
Add more consumption-saving tests

### DIFF
--- a/HARK/ConsumptionSaving/ConsBequestModel.py
+++ b/HARK/ConsumptionSaving/ConsBequestModel.py
@@ -340,13 +340,13 @@ class BequestWarmGlowPortfolioSolver(ConsPortfolioSolver):
 
     def def_utility_funcs(self):
         super().def_utility_funcs()
-
-        self.warm_glow = UtilityFuncStoneGeary(self.BeqCRRA, self.BeqFac, self.BeqShift)
+        BeqFacEff = (1.0 - self.LivPrb) * self.BeqFac
+        self.warm_glow = UtilityFuncStoneGeary(self.BeqCRRA, BeqFacEff, self.BeqShift)
 
     def calc_EndOfPrdvP(self):
         super().calc_EndOfPrdvP()
 
-        self.EndofPrddvda = self.EndOfPrddvda + self.warm_glow.der(self.aNrm_tiled)
+        self.EndOfPrddvda = self.EndOfPrddvda + self.warm_glow.der(self.aNrm_tiled)
         self.EndOfPrddvdaNvrs = self.uPinv(self.EndOfPrddvda)
 
 

--- a/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/ConsGenIncProcessModel.py
@@ -860,6 +860,7 @@ PrstIncCorr = 0.98  # Serial correlation coefficient for permanent income
 # Make a dictionary for the "explicit permanent income" idiosyncratic shocks model
 init_explicit_perm_inc = init_idiosyncratic_shocks.copy()
 init_explicit_perm_inc["pLvlPctiles"] = pLvlPctiles
+init_explicit_perm_inc["pLvlInitStd"] = 0.4  # This *must* be nonzero
 # long run permanent income growth doesn't work yet
 init_explicit_perm_inc["PermGroFac"] = [1.0]
 init_explicit_perm_inc["aXtraMax"] = 30

--- a/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
@@ -310,11 +310,11 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
         """
 
         RfreeNow = super().get_Rfree()
+        RiskyNow = self.shocks["Risky"]
+        # ShareNow = self.controls["Share"]
+        ShareNow = np.ones_like(RiskyNow)  # Only asset is risky asset
 
-        Rport = (
-            self.controls["Share"] * self.shocks["Risky"]
-            + (1.0 - self.controls["Share"]) * RfreeNow
-        )
+        Rport = ShareNow * RiskyNow + (1.0 - ShareNow) * RfreeNow
         self.Rport = Rport
         return Rport
 

--- a/HARK/ConsumptionSaving/tests/test_ConsBequestModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsBequestModel.py
@@ -1,0 +1,61 @@
+import unittest
+from HARK.tests import HARK_PRECISION
+from HARK.ConsumptionSaving.ConsBequestModel import (
+    BequestWarmGlowConsumerType,
+    BequestWarmGlowPortfolioType,
+)
+
+
+class testWarmGlowConsumerType(unittest.TestCase):
+    def setUp(self):
+        self.agent = BequestWarmGlowConsumerType()
+        self.agent.vFuncBool = True
+        self.agent.solve()
+
+    def test_solution(self):
+        cFunc = self.agent.solution[0].cFunc
+        mNrm = 10.0
+        self.assertAlmostEqual(cFunc(mNrm).tolist(), 5.56409, places=HARK_PRECISION)
+
+    # TODO: Turn this on when solver overhaul branch is merged (needs correct value)
+    # def test_value(self):
+    #     vFunc = self.agent.solution[0].vFunc
+    #     mNrm = 10.0
+    #     self.assertAlmostEqual(vFunc(mNrm), -0.0000, places=HARK_PRECISION)
+
+    def test_simulation(self):
+        self.agent.T_sim = 10
+        self.agent.track_vars = ["mNrm", "cNrm", "aNrm"]
+        self.agent.make_shock_history()
+        self.agent.initialize_sim()
+        self.agent.simulate()
+
+
+class testBequestWarmGlowPortfolioType(unittest.TestCase):
+    def setUp(self):
+        self.agent = BequestWarmGlowPortfolioType()
+        self.agent.vFuncBool = True
+        self.agent.solve()
+
+    def test_consumption(self):
+        cFunc = self.agent.solution[0].cFuncAdj
+        mNrm = 10.0
+        self.assertAlmostEqual(cFunc(mNrm).tolist(), 2.19432, places=HARK_PRECISION)
+
+    def test_share(self):
+        ShareFunc = self.agent.solution[0].ShareFuncAdj
+        mNrm = 10.0
+        self.assertAlmostEqual(ShareFunc(mNrm).tolist(), 0.75504, places=HARK_PRECISION)
+
+    # TODO: Turn this on when solver overhaul branch is merged (needs correct value)
+    # def test_value(self):
+    #     vFunc = self.agent.solution[0].vFuncAdj
+    #     mNrm = 10.0
+    #     self.assertAlmostEqual(vFunc(mNrm), -0.0000, places=HARK_PRECISION)
+
+    def test_simulation(self):
+        self.agent.T_sim = 10
+        self.agent.track_vars = ["mNrm", "cNrm", "aNrm", "Share"]
+        self.agent.make_shock_history()
+        self.agent.initialize_sim()
+        self.agent.simulate()

--- a/HARK/ConsumptionSaving/tests/test_ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsGenIncProcessModel.py
@@ -64,9 +64,9 @@ class testIndShockExplicitPermIncConsumerType(unittest.TestCase):
 
     def test_solution(self):
         pLvlGrid = self.agent.pLvlGrid[0]
-        self.assertAlmostEqual(self.agent.pLvlGrid[0][0],
-                               0.27916,
-                               places=HARK_PRECISION)
+        self.assertAlmostEqual(
+            self.agent.pLvlGrid[0][0], 0.27916, places=HARK_PRECISION
+        )
 
         self.assertAlmostEqual(self.agent.solution[0].mLvlMin(pLvlGrid[0]), 0.0)
 
@@ -96,16 +96,16 @@ class testPersistentShockConsumerType(unittest.TestCase):
             5.28844,
             places=HARK_PRECISION,
         )
-    
+
     def test_value(self):
         pLvlGrid = self.agent.pLvlGrid[0]
-        
+
         self.assertTrue(self.agent.vFuncBool)
         self.assertAlmostEqual(
             self.agent.solution[0].vFunc(10, pLvlGrid[3]),
             -0.3655,
-            places=HARK_PRECISION)
-        
+            places=HARK_PRECISION,
+        )
 
     def test_simulation(self):
         self.agent.T_sim = 25
@@ -115,4 +115,4 @@ class testPersistentShockConsumerType(unittest.TestCase):
         self.agent.simulate()
 
         # simulation test -- seed/generator specific
-        #self.assertAlmostEqual(np.mean(self.agent.history["mLvl"]), 1.20439, places=HARK_PRECISION)
+        # self.assertAlmostEqual(np.mean(self.agent.history["mLvl"]), 1.20439, places=HARK_PRECISION)

--- a/HARK/ConsumptionSaving/tests/test_ConsGenIncProcessModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsGenIncProcessModel.py
@@ -18,7 +18,7 @@ GenIncDictionary = {
     "aNrmInitMean": 0.0,  # Mean of log initial assets (only matters for simulation)
     "aNrmInitStd": 1.0,  # Standard deviation of log initial assets (only for simulation)
     "pLvlInitMean": 0.0,  # Mean of log initial permanent income (only matters for simulation)
-    "pLvlInitStd": 0.0,  # Standard deviation of log initial permanent income (only matters for simulation)
+    "pLvlInitStd": 0.4,  # Standard deviation of log initial permanent income (only matters for simulation)
     "PermGroFacAgg": 1.0,  # Aggregate permanent income growth factor (only matters for simulation)
     "T_age": None,  # Age after which simulated agents are automatically killed
     "T_cycle": 1,  # Number of periods in the cycle for this agent type
@@ -64,13 +64,15 @@ class testIndShockExplicitPermIncConsumerType(unittest.TestCase):
 
     def test_solution(self):
         pLvlGrid = self.agent.pLvlGrid[0]
-        self.assertAlmostEqual(self.agent.pLvlGrid[0][0], 1.0)
+        self.assertAlmostEqual(self.agent.pLvlGrid[0][0],
+                               0.27916,
+                               places=HARK_PRECISION)
 
         self.assertAlmostEqual(self.agent.solution[0].mLvlMin(pLvlGrid[0]), 0.0)
 
         self.assertAlmostEqual(
             self.agent.solution[0].cFunc(10, pLvlGrid[5]).tolist(),
-            5.60301,
+            5.40844,
             places=HARK_PRECISION,
         )
 
@@ -91,17 +93,26 @@ class testPersistentShockConsumerType(unittest.TestCase):
 
         self.assertAlmostEqual(
             self.agent.solution[0].cFunc(10, pLvlGrid[1]).tolist(),
-            5.60301,
+            5.28844,
             places=HARK_PRECISION,
         )
+    
+    def test_value(self):
+        pLvlGrid = self.agent.pLvlGrid[0]
+        
+        self.assertTrue(self.agent.vFuncBool)
+        self.assertAlmostEqual(
+            self.agent.solution[0].vFunc(10, pLvlGrid[3]),
+            -0.3655,
+            places=HARK_PRECISION)
+        
 
     def test_simulation(self):
         self.agent.T_sim = 25
 
-        # why does ,"bLvlNow" not work here?
         self.agent.track_vars = ["aLvl", "mLvl", "cLvl", "pLvl"]
         self.agent.initialize_sim()
         self.agent.simulate()
 
         # simulation test -- seed/generator specific
-        # self.assertAlmostEqual(np.mean(self.agent.history["mLvl"]), 1.20439, place = HARK_PRECISION)
+        #self.assertAlmostEqual(np.mean(self.agent.history["mLvl"]), 1.20439, places=HARK_PRECISION)

--- a/HARK/ConsumptionSaving/tests/test_ConsMedModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsMedModel.py
@@ -1,15 +1,34 @@
 import unittest
-
+from HARK.tests import HARK_PRECISION
 from HARK.ConsumptionSaving.ConsMedModel import MedShockConsumerType
 
 
 class testMedShockConsumerType(unittest.TestCase):
     def setUp(self):
         self.agent = MedShockConsumerType()
-
-    def test_solution(self):
+        self.agent.vFuncBool = True
         self.agent.solve()
 
+    def test_solution(self):
+        cFunc = self.agent.solution[0].cFunc
+        MedFunc = self.agent.solution[0].MedFunc
+        mLvl = 10.0
+        pLvl = 2.0
+        Shk = 1.5
+        self.assertAlmostEqual(
+            cFunc(mLvl, pLvl, Shk).tolist(), 4.16259, places=HARK_PRECISION
+        )
+        self.assertAlmostEqual(
+            MedFunc(mLvl, pLvl, Shk).tolist(), 2.45412, places=HARK_PRECISION
+        )
+
+    def test_value(self):
+        vFunc = self.agent.solution[0].vFunc
+        mLvl = 10.0
+        pLvl = 2.0
+        self.assertAlmostEqual(vFunc(mLvl, pLvl), -0.32428, places=HARK_PRECISION)
+
+    def test_simulation(self):
         self.agent.T_sim = 10
         self.agent.track_vars = ["mLvl", "cLvl", "Med"]
         self.agent.make_shock_history()

--- a/HARK/ConsumptionSaving/tests/test_ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsRiskyAssetModel.py
@@ -1,0 +1,28 @@
+import unittest
+from HARK.tests import HARK_PRECISION
+from HARK.ConsumptionSaving.ConsRiskyAssetModel import IndShockRiskyAssetConsumerType
+
+
+class testRiskyAssetConsumerType(unittest.TestCase):
+    def setUp(self):
+        self.agent = IndShockRiskyAssetConsumerType()
+        self.agent.vFuncBool = False
+        self.agent.solve()
+
+    def test_solution(self):
+        cFunc = self.agent.solution[0].cFunc
+        mNrm = 10.0
+        self.assertAlmostEqual(cFunc(mNrm).tolist(), 5.637216, places=HARK_PRECISION)
+
+    # TODO: Turn this on after solver overhaul branch is merged
+    # def test_value(self):
+    #     vFunc = self.agent.solution[0].vFunc
+    #     mNrm = 10.0
+    #     self.assertAlmostEqual(vFunc(mNrm), -0.0000, places=HARK_PRECISION)
+
+    def test_simulation(self):
+        self.agent.T_sim = 10
+        self.agent.track_vars = ["mNrm", "cNrm", "aNrm"]
+        self.agent.make_shock_history()
+        self.agent.initialize_sim()
+        self.agent.simulate()

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -896,9 +896,8 @@ class test_Transition_Matrix_Methods(unittest.TestCase):
         asset = example1.aPol_Grid  # Normalized Asset Policy Grid
 
         example1.calc_ergodic_dist()
-        vecDstn = (
-            example1.vec_erg_dstn
-        )  # Distribution of market resources and permanent income as a vector (m*p)x1 vector where
+        vecDstn = example1.vec_erg_dstn
+        # Distribution of market resources and permanent income as a vector (m*p)x1 vector where
 
         # Compute Aggregate Consumption and Aggregate Assets
         gridc = np.zeros((len(c), len(p)))

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -896,7 +896,9 @@ class test_Transition_Matrix_Methods(unittest.TestCase):
         asset = example1.aPol_Grid  # Normalized Asset Policy Grid
 
         example1.calc_ergodic_dist()
-        vecDstn = example1.vec_erg_dstn  # Distribution of market resources and permanent income as a vector (m*p)x1 vector where
+        vecDstn = (
+            example1.vec_erg_dstn
+        )  # Distribution of market resources and permanent income as a vector (m*p)x1 vector where
 
         # Compute Aggregate Consumption and Aggregate Assets
         gridc = np.zeros((len(c), len(p)))


### PR DESCRIPTION
This PR *only* adds new tests (and makes tiny adjustments to old ones) for consumption-saving models and should be merged *before* my solvers overhaul branch. But not yet because I'm actively adding tests.
