### PR TITLE
Correct human wealth with risky returns

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -22,8 +22,9 @@ Release Date: TBA
 - Add option to pass pre-built grid to `LinearFast`. [1388](https://github.com/econ-ark/HARK/pull/1388)
 - Moves calculation of stable points out of ConsIndShock solver, into method called by post_solve [#1349](https://github.com/econ-ark/HARK/pull/1349)
 - Adds cubic spline interpolation and value function construction to "warm glow bequest" models.
-- Fixes cubic spline interpolation for ConsMedShockModel
+- Fixes cubic spline interpolation for ConsMedShockModel.
 - Moves computation of "stable points" from inside of ConsIndShock solver to a post-solution method. [1349](https://github.com/econ-ark/HARK/pull/1349)
+- Corrects calculation of "human wealth" under risky returns, providing correct limiting linear consumption function. [1403](https://github.com/econ-ark/HARK/pull/1403)
 
 ### 0.14.1
 

--- a/HARK/ConsumptionSaving/ConsMarkovModel.py
+++ b/HARK/ConsumptionSaving/ConsMarkovModel.py
@@ -381,9 +381,14 @@ def solve_one_period_ConsMarkov(
     MPCmaxEff = MPCmaxNow
     MPCmaxEff[BoroCnstNat_list < mNrmMin_list] = 1.0
 
-    # Calculate the current Markov-state-conditional PDV of human wealth
+    # Calculate the current Markov-state-conditional PDV of human wealth, correctly
+    # accounting for risky returns and risk aversion
     hNrmPlusIncNext = Ex_IncNextAll + solution_next.hNrm
-    hNrmNow = np.dot(MrkvArray, (PermGroFac_list / Rfree_list) * hNrmPlusIncNext)
+    R_adj = np.dot(MrkvArray, Rfree_list ** (1.0 - CRRA))
+    hNrmNow = (
+        np.dot(MrkvArray, (PermGroFac_list / Rfree_list**CRRA) * hNrmPlusIncNext)
+        / R_adj
+    )
 
     # Calculate the lower bound on MPC as m gets arbitrarily large
     temp = (

--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -458,9 +458,7 @@ def solve_one_period_ConsPortfolio(
     # This basic equation works if there's no correlation among shocks
     # hNrmNow = (PermGroFac/Rfree)*(1 + solution_next.hNrm)
 
-    # The above attempts to pin down the limiting consumption function for this
-    # model, however it is not clear why it creates bugs, so for now we allow
-    # for a linear extrapolation beyond the last asset point
+    # Set the terms of the limiting linear consumption function as mNrm goes to infinity
     cFuncLimitIntercept = MPCminNow * hNrmNow
     cFuncLimitSlope = MPCminNow
 

--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -227,6 +227,8 @@ class PortfolioConsumerType(RiskyAssetConsumerType):
             dvdmFuncFxd=dvdmFuncFxd_terminal,
             dvdsFuncFxd=dvdsFuncFxd_terminal,
         )
+        self.solution_terminal.hNrm = 0.0
+        self.solution_terminal.MPCmin = 1.0
 
     def initialize_sim(self):
         """
@@ -428,6 +430,39 @@ def solve_one_period_ConsPortfolio(
     Risky_next = RiskyDstn.atoms
     RiskyMax = np.max(Risky_next)
     RiskyMin = np.min(Risky_next)
+    
+    # Perform an alternate calculation of the absolute patience factor when
+    # returns are risky. This uses the Merton-Samuelson limiting risky share,
+    # which is what's relevant as mNrm goes to infinity.
+    def calc_Radj(R):
+        Rport = ShareLimit * R + (1.0 - ShareLimit) * Rfree
+        return Rport ** (1.0 - CRRA)
+
+    R_adj = expected(calc_Radj, RiskyDstn)[0]
+    PatFac = (DiscFacEff * R_adj) ** (1.0 / CRRA)
+    MPCminNow = 1.0 / (1.0 + PatFac / solution_next.MPCmin)
+
+    # Also perform an alternate calculation for human wealth under risky returns
+    def calc_hNrm(S):
+        Risky = S["Risky"]
+        PermShk = S["PermShk"]
+        TranShk = S["TranShk"]
+        G = PermGroFac * PermShk
+        Rport = ShareLimit * Risky + (1.0 - ShareLimit) * Rfree
+        hNrm = (G / Rport**CRRA) * (TranShk + solution_next.hNrm)
+        return hNrm
+
+    # This correctly accounts for risky returns and risk aversion
+    hNrmNow = expected(calc_hNrm, ShockDstn) / R_adj
+    
+    # This basic equation works if there's no correlation among shocks
+    # hNrmNow = (PermGroFac/Rfree)*(1 + solution_next.hNrm)
+
+    # The above attempts to pin down the limiting consumption function for this
+    # model, however it is not clear why it creates bugs, so for now we allow
+    # for a linear extrapolation beyond the last asset point
+    cFuncLimitIntercept = MPCminNow * hNrmNow
+    cFuncLimitSlope = MPCminNow
 
     # bNrm represents R*a, balances after asset return shocks but before income.
     # This just uses the highest risky return as a rough shifter for the aXtraGrid.
@@ -917,6 +952,8 @@ def solve_one_period_ConsPortfolio(
         EndOfPrddvda_fxd=save_points["eop_dvda_fxd"],
         EndOfPrddvds_fxd=save_points["eop_dvds_fxd"],
     )
+    solution_now.hNrm = hNrmNow
+    solution_now.MPCmin = MPCminNow
     return solution_now
 
 

--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -430,7 +430,7 @@ def solve_one_period_ConsPortfolio(
     Risky_next = RiskyDstn.atoms
     RiskyMax = np.max(Risky_next)
     RiskyMin = np.min(Risky_next)
-    
+
     # Perform an alternate calculation of the absolute patience factor when
     # returns are risky. This uses the Merton-Samuelson limiting risky share,
     # which is what's relevant as mNrm goes to infinity.
@@ -454,7 +454,7 @@ def solve_one_period_ConsPortfolio(
 
     # This correctly accounts for risky returns and risk aversion
     hNrmNow = expected(calc_hNrm, ShockDstn) / R_adj
-    
+
     # This basic equation works if there's no correlation among shocks
     # hNrmNow = (PermGroFac/Rfree)*(1 + solution_next.hNrm)
 

--- a/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
@@ -271,7 +271,9 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
 
             SharePF = minimize_scalar(
                 temp_f, bracket=(0.0, 1.0), method="golden", tol=1e-10
-            ).x[0]
+            ).x
+            if type(SharePF) is np.array:
+                SharePF = SharePF[0]
             self.ShareLimit = SharePF
             self.add_to_time_inv("ShareLimit")
 


### PR DESCRIPTION
Through a combination of math and experimentation, I've found the correct computation of "human wealth" in the presence of risky returns. I've implemented it for RiskyAssetModel and FixedShareModel. On the next commit I'll get it working for the PortfolioChoice models, and then turn to ConsMarkovModel.

The good news is that I have the right answer. The bad news is that (other than partly getting to it via whiteboard math and following some clues from experimentation) I don't have a proof of *why* it's correct. I'll write it up in a short file and circulate.

This PR will also fix a very small mistake in the computation of hNrm by calc_limiting_values; that code uses an alternate definition of hNrm that will be off by exactly 1.

- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
