### PR TITLE
move calibration out of DBlock definition, see #1371

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -26,6 +26,7 @@ Release Date: TBA
 - Fixes cubic spline interpolation for ConsMedShockModel.
 - Moves computation of "stable points" from inside of ConsIndShock solver to a post-solution method. [1349](https://github.com/econ-ark/HARK/pull/1349)
 - Corrects calculation of "human wealth" under risky returns, providing correct limiting linear consumption function. [1403](https://github.com/econ-ark/HARK/pull/1403)
+- Removed 'parameters' from new block definitions; these are now 'calibrations' provided separately.
 
 ### 0.14.1
 

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -46,6 +46,5 @@ class DBlock:
     name: str = ""
     description: str = ""
     shocks: dict = field(default_factory=dict)
-    parameters: dict = field(default_factory=dict)
     dynamics: dict = field(default_factory=dict)
     reward: dict = field(default_factory=dict)

--- a/HARK/models/fisher.py
+++ b/HARK/models/fisher.py
@@ -9,16 +9,17 @@ from HARK.model import Control, DBlock
 # But it would be better to have a more graceful Python version as well.
 CRRA = (2.0,)
 
+calibration = {
+    "DiscFac": 0.96,
+    "CRRA": CRRA,
+    "Rfree": 1.03,
+    "y": [1.0, 1.0],
+    "BoroCnstArt": None,
+}
+
 block = DBlock(
     **{
         "shocks": {},
-        "parameters": {
-            "DiscFac": 0.96,
-            "CRRA": CRRA,
-            "Rfree": 1.03,
-            "y": [1.0, 1.0],
-            "BoroCnstArt": None,
-        },
         "dynamics": {
             "m": lambda Rfree, a, y: Rfree * a + y,
             "c": Control(["m"]),

--- a/HARK/models/perfect_foresight.py
+++ b/HARK/models/perfect_foresight.py
@@ -6,19 +6,20 @@ from HARK.model import Control, DBlock
 # But it would be better to have a more graceful Python version as well.
 LivPrb = 0.98
 
+calibration = {
+    "DiscFac": 0.96,
+    "CRRA": 2.0,
+    "Rfree": 1.03,
+    "LivPrb": LivPrb,
+    "PermGroFac": 1.01,
+    "BoroCnstArt": None,
+}
+
 block = DBlock(
     **{
         "name": "consumption",
         "shocks": {
             "live": Bernoulli(p=LivPrb),
-        },
-        "parameters": {
-            "DiscFac": 0.96,
-            "CRRA": 2.0,
-            "Rfree": 1.03,
-            "LivPrb": LivPrb,
-            "PermGroFac": 1.01,
-            "BoroCnstArt": None,
         },
         "dynamics": {
             "y": lambda p: p,

--- a/HARK/models/perfect_foresight_normalized.py
+++ b/HARK/models/perfect_foresight_normalized.py
@@ -7,18 +7,19 @@ from HARK.model import Control, DBlock
 CRRA = (2.0,)
 LivPrb = 0.98
 
+calibration = {
+    "DiscFac": 0.96,
+    "CRRA": CRRA,
+    "Rfree": 1.03,
+    "LivPrb": LivPrb,
+    "PermGroFac": 1.01,
+    "BoroCnstArt": None,
+}
+
 block = DBlock(
     **{
         "shocks": {
             "live": Bernoulli(p=LivPrb),
-        },
-        "parameters": {
-            "DiscFac": 0.96,
-            "CRRA": CRRA,
-            "Rfree": 1.03,
-            "LivPrb": LivPrb,
-            "PermGroFac": 1.01,
-            "BoroCnstArt": None,
         },
         "dynamics": {
             "p": lambda PermGroFac, p: PermGroFac * p,

--- a/HARK/models/test_models.py
+++ b/HARK/models/test_models.py
@@ -29,6 +29,7 @@ PFexample.solve()
 class test_pfm(unittest.TestCase):
     def setUp(self):
         self.mcs = AgentTypeMonteCarloSimulator(
+            pfm.calibration,
             pfm.block,
             {"c": lambda m: PFexample.solution[0].cFunc(m)},
             # danger: normalized decision rule for unnormalized problem
@@ -50,6 +51,7 @@ class test_pfm(unittest.TestCase):
 class test_pfnm(unittest.TestCase):
     def setUp(self):
         self.mcs = AgentTypeMonteCarloSimulator(  ### Use fm, blockified
+            pfnm.calibration,
             pfnm.block,
             {"c_nrm": lambda m_nrm: PFexample.solution[0].cFunc(m_nrm)},
             {  # initial states

--- a/HARK/simulation/test_monte_carlo.py
+++ b/HARK/simulation/test_monte_carlo.py
@@ -53,15 +53,15 @@ class test_simulate_dynamics(unittest.TestCase):
 
 class test_AgentTypeMonteCarloSimulator(unittest.TestCase):
     def setUp(self):
+        self.calibration = {  # TODO
+            "G": 1.05,
+        }
         self.block = DBlock(
             **{
                 "shocks": {
                     "theta": MeanOneLogNormal(1),
                     "agg_R": Aggregate(MeanOneLogNormal(1)),
                     "live": Bernoulli(p=0.98),
-                },
-                "parameters": {  # TODO
-                    "G": 1.05,
                 },
                 "dynamics": {
                     "b": lambda agg_R, G, a: agg_R * G * a,
@@ -78,6 +78,7 @@ class test_AgentTypeMonteCarloSimulator(unittest.TestCase):
 
     def test_simulate(self):
         self.simulator = AgentTypeMonteCarloSimulator(
+            self.calibration,
             self.block,
             self.dr,
             self.initial,
@@ -89,7 +90,7 @@ class test_AgentTypeMonteCarloSimulator(unittest.TestCase):
 
         a1 = history["a"][5]
         b1 = (
-            history["a"][4] * history["agg_R"][5] * self.block.parameters["G"]
+            history["a"][4] * history["agg_R"][5] * self.calibration["G"]
             + history["theta"][5]
             - history["c"][5]
         )
@@ -98,6 +99,7 @@ class test_AgentTypeMonteCarloSimulator(unittest.TestCase):
 
     def test_make_shock_history(self):
         self.simulator = AgentTypeMonteCarloSimulator(
+            self.calibration,
             self.block,
             self.dr,
             self.initial,
@@ -118,6 +120,9 @@ class test_AgentTypeMonteCarloSimulator(unittest.TestCase):
 
 class test_AgentTypeMonteCarloSimulatorAgeVariance(unittest.TestCase):
     def setUp(self):
+        self.calibration = {  # TODO
+            "G": 1.05,
+        }
         self.block = DBlock(
             **{
                 "shocks": {
@@ -125,9 +130,6 @@ class test_AgentTypeMonteCarloSimulatorAgeVariance(unittest.TestCase):
                     "agg_R": Aggregate(MeanOneLogNormal(1)),
                     "live": Bernoulli(p=0.98),
                     "psi": IndexDistribution(MeanOneLogNormal, {"sigma": [1.0, 1.1]}),
-                },
-                "parameters": {  # TODO
-                    "G": 1.05,
                 },
                 "dynamics": {
                     "b": lambda agg_R, G, a: agg_R * G * a,
@@ -143,6 +145,7 @@ class test_AgentTypeMonteCarloSimulatorAgeVariance(unittest.TestCase):
 
     def test_simulate(self):
         self.simulator = AgentTypeMonteCarloSimulator(
+            self.calibration,
             self.block,
             self.dr,
             self.initial,

--- a/HARK/tests/test_model.py
+++ b/HARK/tests/test_model.py
@@ -12,14 +12,6 @@ test_block_A_data = {
     "shocks": {
         "live": Bernoulli(p=LivPrb),
     },
-    "parameters": {
-        "DiscFac": 0.96,
-        "CRRA": 3,
-        "Rfree": 1.03,
-        "LivPrb": LivPrb,
-        "PermGroFac": 1.01,
-        "BoroCnstArt": None,
-    },
     "dynamics": {
         "y": lambda p: p,
         "m": lambda Rfree, a, y: Rfree * a + y,

--- a/examples/MonteCarlo/Generic Monte Carlo Perfect Foresight.ipynb
+++ b/examples/MonteCarlo/Generic Monte Carlo Perfect Foresight.ipynb
@@ -65,7 +65,7 @@
     {
      "data": {
       "text/plain": [
-       "<HARK.ConsumptionSaving.ConsIndShockModel.PerfForesightConsumerType at 0x72993b60ab60>"
+       "<HARK.ConsumptionSaving.ConsIndShockModel.PerfForesightConsumerType at 0x7f62f2e1ad70>"
       ]
      },
      "execution_count": 4,
@@ -643,7 +643,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_19186/109081091.py:2: RuntimeWarning: divide by zero encountered in log\n",
+      "/tmp/ipykernel_55278/109081091.py:2: RuntimeWarning: divide by zero encountered in log\n",
       "  np.log(\n"
      ]
     },
@@ -743,7 +743,7 @@
     {
      "data": {
       "text/plain": [
-       "DBlock(name='', description='', shocks={'live': <HARK.distribution.Bernoulli object at 0x7299aa70d030>}, parameters={'DiscFac': 0.96, 'CRRA': (2.0,), 'Rfree': 1.03, 'LivPrb': 0.98, 'PermGroFac': 1.01, 'BoroCnstArt': None}, dynamics={'p': <function <lambda> at 0x72993b494af0>, 'r_eff': <function <lambda> at 0x72993b494dc0>, 'b_nrm': <function <lambda> at 0x72993b494e50>, 'm_nrm': <function <lambda> at 0x72993b494ee0>, 'c_nrm': <HARK.model.Control object at 0x72993b656c50>, 'a_nrm': <function <lambda> at 0x72993b495000>}, reward={'u': <function <lambda> at 0x72993b495480>})"
+       "DBlock(name='', description='', shocks={'live': <HARK.distribution.Bernoulli object at 0x7f62f2c0f3d0>}, dynamics={'p': <function <lambda> at 0x7f62f2c9ce50>, 'r_eff': <function <lambda> at 0x7f62f2c9cee0>, 'b_nrm': <function <lambda> at 0x7f62f2c9cf70>, 'm_nrm': <function <lambda> at 0x7f62f2c9d000>, 'c_nrm': <HARK.model.Control object at 0x7f62f2c0f700>, 'a_nrm': <function <lambda> at 0x7f62f2c9d120>}, reward={'u': <function <lambda> at 0x7f62f2c9d5a0>})"
       ]
      },
      "execution_count": 12,
@@ -763,6 +763,7 @@
    "outputs": [],
    "source": [
     "pfn_simulator = AgentTypeMonteCarloSimulator(\n",
+    "    pfn.calibration,\n",
     "    pfn.block,\n",
     "    {\"c_nrm\": lambda m_nrm: PFexample.solution[0].cFunc(m_nrm)},\n",
     "    {  # initial states\n",
@@ -1698,7 +1699,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_19186/1229691935.py:2: RuntimeWarning: divide by zero encountered in log\n",
+      "/tmp/ipykernel_55278/1229691935.py:2: RuntimeWarning: divide by zero encountered in log\n",
       "  np.log(\n"
      ]
     },
@@ -1736,7 +1737,7 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x72993b5d4d90>]"
+       "[<matplotlib.lines.Line2D at 0x7f62f2ee7670>]"
       ]
      },
      "execution_count": 19,


### PR DESCRIPTION
This separates out the calibration data from the dynamics in the DBlock

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
