### PR TITLE
a general value backwards induction algorithm built on DBlocks

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -24,6 +24,7 @@ Note: Due to major changes on this release, you may need to adjust how AgentType
 - All methods that construct inputs for solvers are now functions that are specified in the dictionary attribute `constructors`. [#1410](https://github.com/econ-ark/HARK/pull/1410)
 - Such constructed inputs can use alternate parameterizations / formats by changing the `constructor` function and providing its arguments in `parameters`.
 - Move `HARK.datasets` to `HARK.Calibration` for better organization of data and calibration tools. [#1430](https://github.com/econ-ark/HARK/pull/1430)
+- Adds `HARK.algos.vbi` as a general algorithm for solving the optimization step of an agent's problem.
 
 ### Minor Changes
 

--- a/Documentation/reference/tools/algos.rst
+++ b/Documentation/reference/tools/algos.rst
@@ -1,0 +1,7 @@
+algos
+--------
+
+.. toctree::
+   :maxdepth: 3
+
+   algos/vbi

--- a/Documentation/reference/tools/algos/vbi.rst
+++ b/Documentation/reference/tools/algos/vbi.rst
@@ -1,0 +1,7 @@
+algos.vbi
+----------
+
+.. automodule:: HARK.algos.vbi
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/Documentation/reference/tools/index.rst.orig
+++ b/Documentation/reference/tools/index.rst.orig
@@ -1,0 +1,27 @@
+:orphan:
+
+Tools
+=====
+
+<<<<<<< HEAD
+.. toctree::
+   :maxdepth: 3
+
+   algos
+   core
+   dcegm
+   distribution
+   econforgeinterp
+   estimation
+   frame
+   helpers
+   interpolation
+   numba
+   parallel
+   rewards
+   simulation
+   utilities
+   validators
+=======
+See :doc:`../index`.
+>>>>>>> master

--- a/HARK/algos/vbi.py
+++ b/HARK/algos/vbi.py
@@ -1,0 +1,153 @@
+"""
+Use backwards induction to derive the arrival value function
+from a continuation value function and stage dynamics.
+"""
+
+from HARK.model import DBlock
+import itertools
+from scipy.optimize import minimize, brentq
+from typing import Mapping
+
+
+def get_action_rule(action):
+    """
+    Produce a function from any inputs to a given value.
+    This is useful for constructing decision rules with fixed actions.
+    """
+
+    def ar(*args):
+        return action
+
+    return ar
+
+
+def ar_from_data(da):
+    """
+    Produce a function from any inputs to a given value.
+    This is useful for constructing decision rules with fixed actions.
+    """
+
+    def ar(**args):
+        return da.interp(**args)
+
+    return ar
+
+
+Grid = Mapping[str, Sequence]
+
+
+def grid_to_data_array(
+    grid: Grid = {},  ## TODO: Better data structure here.
+):
+    """
+    Construct a zero-valued DataArray with the coordinates
+    based on the Grid passed in.
+
+    Parameters
+    ----------
+    grid: Grid
+        A mapping from variable labels to a sequence of numerical values.
+
+    Returns
+    --------
+    da xarray.DataArray
+        An xarray.DataArray with coordinates given by both grids.
+    """
+
+    coords = {**grid}
+
+    da = xr.DataArray(
+        np.empty([len(v) for v in coords.values()]), dims=coords.keys(), coords=coords
+    )
+
+    return da
+
+
+def vbi_solve(
+    block: DBlock, continuation, state_grid: Grid, disc_params, calibration={}
+):
+    """
+    Solve a DBlock using backwards induction on the value function.
+
+    Parameters
+    -----------
+    block
+    continuation
+
+    state_grid: Grid
+        This is a grid over all variables that the optimization will range over.
+        This should be just the information set of the decision variables.
+
+    disc_params
+    calibration
+    """
+
+    # state-rule value function
+    srv_function = block.get_state_rule_value_function_from_continuation(continuation)
+
+    controls = block.get_controls()
+
+    # pseudo
+    policy_data = grid_to_data_array(state_grid)
+    value_data = grid_to_data_array(state_grid)
+
+    # loop through every point in the state grid
+    for state_point in itertools.product(*state_grid.values()):
+        # build a dictionary from these states, as scope for the optimization
+        state_vals = {k: v for k, v in zip(state_grid.keys(), state_point)}
+
+        # copy calibration
+        # update with state_vals
+        # this becomes the before-action states
+        pre_states = state_vals + parameters
+
+        # prepare function to optimize
+        def negated_value(a):  # old! (should be negative)
+            dr = {c: get_action_rule(a[i]) for i, c in enumerate(controls)}
+
+            # negative, for minimization later
+            return -srv_function(pre_states, dr)
+
+        ## get lower bound.
+        ## not yet implemented
+        lower_bound = np.array([-1e-12] * len(controls))  ## a really low number!
+
+        ## get upper bound
+        ## not yet implemented
+        upper_bound = np.array([1e12] * len(controls))
+
+        # pseudo
+        # optimize_action(pre_states, srv_function)
+
+        a_best, root_res = minimize(  # choice of
+            negated_value, full_output=True
+        )
+
+        dr_best = {c: get_action_rule(a_best[i]) for i, c in enumerate(controls)}
+
+        if root_res.converged:
+            policy_data.sel(**state_vals).variable.data.put(0, a_best)
+            value_data.sel(**state_vals).variable.data.put(
+                0, srv_function(pre_states, dr_best)
+            )
+        else:
+            print(f"Optimization failure at {state_vals}.")
+            print(root_res)
+
+            dr_best = {c: get_action_rule(root_res[i]) for i, c in enumerate(controls)}
+
+            policy_data.sel(**state_vals).variable.data.put(0, res.root)  # ?
+            value_data.sel(**state_vals).variable.data.put(
+                0, srv_function(pre_states, dr_best)
+            )
+
+    # use the xarray interpolator to create a decision rule.
+    dr_from_data = {
+        c: ar_from_data(da)  # maybe needs to be more sensitive to the information set
+        for i, c in enumerate(controls)
+    }
+
+    dec_vf = block.get_decision_value_function(dr_from_data, continuation)
+    arr_vf = block.get_arrival_value_function(disc_params, dr_from_data, continuation)
+
+    return dr_from_data, dec_vf, arr_vf

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -161,6 +161,14 @@ class DBlock:
     def get_vars(self):
         return list(self.shocks.keys()) + list(self.dynamics.keys())
 
+    def get_controls(self):
+        """
+        TODO: Repeated in RBlock. Move to higher order class.
+        """
+        dyn = self.get_dynamics()
+
+        return [varn for varn in dyn if isinstance(dyn[varn], Control)]
+
     def transition(self, pre, dr):
         """
         Returns variable values given previous values and decision rule for all controls.


### PR DESCRIPTION
This PR aims to provide a general backwards induction algorithm that operates on a single DBlock.

It simply arranges the pieces that come with the DBlock (decision value function, arrival value function), in a sensible way, with an optimization over the action space to find the best action at each point in the state grid.

While the algorithm is not as good as FOC or EGM methods, I'm doing this for several reasons:
- As a way to work out the API design for solution algorithms more generally
- As a way to put pressure on the HARK 1.0 proto-language to include details that have been missing (such as bounds on actions)
- As a way to demonstrate the way discretization of shocks is used for solutions, so that I can build a demo of how the same discretization can be used for solution and simulation. (This is a target for my upcoming SciPy deliverable)

The first commit of this PR just sketches the algorithm out, but it isn't tested.

One question is how to design this so that it is more agnostic to different optimizers. I know @alanlujan91 is keen on estimagic.

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
