### PR TITLE
discretize() methods for blocks

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -8,6 +8,19 @@ For more information on HARK, see [our Github organization](https://github.com/e
 
 ## Changes
 
+### 0.16.0
+
+Release Date: TBD
+
+### Major Changes
+
+- Adds a discretize method to DBlocks and RBlocks (#1460)[https://github.com/econ-ark/HARK/pull/1460]
+
+### Minor Changes
+
+none
+
+
 ### 0.15.1
 
 Release Date: June 15, 2024

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -289,18 +289,17 @@ class RBlock(Block):
         Recursively discretizes all the blocks.
         It replaces any DBlocks with new blocks with discretized shocks.
         """
-        # we will be mutating self.blocks so need to iterate through a copy
-        ib = copy(self.blocks)
+        cbs = copy(self.blocks)
 
-        for i, b in enumerate(ib):
+        for i, b in list(enumerate(cbs)):
             if isinstance(b, DBlock):
                 nb = b.discretize(disc_params)
-                self.blocks[i] = nb
+                cbs[i] = nb
             elif isinstance(b, RBlock):
                 b.discretize(disc_params)
 
-        # returns the rblock, which is modified, to align the type signatures across subclasses
-        return self
+        # returns a copy of the RBlock with the blocks replaced
+        return replace(self, blocks = cbs)
 
     def get_shocks(self):
         ### TODO: Bug in here is causing AttributeError: 'set' object has no attribute 'draw'

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -2,7 +2,8 @@
 Tools for crafting models.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from copy import deepcopy
 from HARK.distribution import (
     Distribution,
     DiscreteDistributionLabeled,
@@ -151,6 +152,24 @@ class DBlock:
     shocks: dict = field(default_factory=dict)
     dynamics: dict = field(default_factory=dict)
     reward: dict = field(default_factory=dict)
+
+    def discretize(self, disc_params):
+        """
+        Returns a new DBlock which is a copy of this one, but with shock discretized.
+        """
+
+        disc_shocks = {}
+
+        for shockn in self.shocks:
+            if shockn in disc_params:
+                disc_shocks[shockn] = self.shocks[shockn].discretize(**disc_params[shockn])
+            else:
+                disc_shocks[shockn] = deepcopy(self.shocks[shockn])
+
+        # replace returns a modified copy
+        new_dblock = replace(self, shocks = disc_shocks)
+
+        return new_dblock
 
     def get_shocks(self):
         return self.shocks

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -299,7 +299,7 @@ class RBlock(Block):
                 b.discretize(disc_params)
 
         # returns a copy of the RBlock with the blocks replaced
-        return replace(self, blocks = cbs)
+        return replace(self, blocks=cbs)
 
     def get_shocks(self):
         ### TODO: Bug in here is causing AttributeError: 'set' object has no attribute 'draw'

--- a/HARK/tests/test_model.py
+++ b/HARK/tests/test_model.py
@@ -44,6 +44,11 @@ class test_DBlock(unittest.TestCase):
     def test_init(self):
         self.assertEqual(self.test_block_A.name, "test block A")
 
+    def test_discretize(self):
+        dbl = self.cblock.discretize({"theta" : {"N" : 5}})
+
+        self.assertEqual(len(dbl.shocks["theta"].pmv), 5)
+
     def test_transition(self):
         post = self.cblock.transition(self.dpre, self.dr)
 

--- a/HARK/tests/test_model.py
+++ b/HARK/tests/test_model.py
@@ -45,7 +45,7 @@ class test_DBlock(unittest.TestCase):
         self.assertEqual(self.test_block_A.name, "test block A")
 
     def test_discretize(self):
-        dbl = self.cblock.discretize({"theta" : {"N" : 5}})
+        dbl = self.cblock.discretize({"theta": {"N": 5}})
 
         self.assertEqual(len(dbl.shocks["theta"].pmv), 5)
 
@@ -84,6 +84,8 @@ class test_RBlock(unittest.TestCase):
         self.test_block_C = model.DBlock(**test_block_C_data)
         self.test_block_D = model.DBlock(**test_block_D_data)
 
+        self.cpp = cons.cons_portfolio_problem
+
     def test_init(self):
         r_block_tree = model.RBlock(
             blocks=[
@@ -94,3 +96,9 @@ class test_RBlock(unittest.TestCase):
 
         r_block_tree.get_shocks()
         self.assertEqual(len(r_block_tree.get_shocks()), 3)
+
+    def test_discretize(self):
+        cppd = self.cpp.discretize({"theta": {"N": 5}, "risky_return": {"N": 6}})
+
+        self.assertEqual(len(cppd.get_shocks()["theta"].pmv), 5)
+        self.assertEqual(len(cppd.get_shocks()["risky_return"].pmv), 6)

--- a/HARK/tests/test_model.py
+++ b/HARK/tests/test_model.py
@@ -1,6 +1,6 @@
 import unittest
 
-from HARK.distribution import Bernoulli
+from HARK.distribution import Bernoulli, DiscreteDistribution
 import HARK.model as model
 from HARK.model import Control
 import HARK.models.consumer as cons
@@ -102,3 +102,7 @@ class test_RBlock(unittest.TestCase):
 
         self.assertEqual(len(cppd.get_shocks()["theta"].pmv), 5)
         self.assertEqual(len(cppd.get_shocks()["risky_return"].pmv), 6)
+
+        self.assertFalse(
+            isinstance(self.cpp.get_shocks()["theta"], DiscreteDistribution)
+        )


### PR DESCRIPTION
Introduces `discretize` methods for blocks, which apply the discretization parameters to the shocks.

In the RBlock case, this is done recursively.

The point of this is to provide an API which a user can call to modify the 'true' version of a model into a discretized one.
The discretized model can then be used for solution and simulation.

(in the future, a YAML configuration will interact with this API)


<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
