### PR TITLE
Construct shocks with mathematical expression arguments using calibration scope

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -17,6 +17,7 @@ Release Date: TBD
 - Adds a discretize method to DBlocks and RBlocks (#1460)[https://github.com/econ-ark/HARK/pull/1460]
 - Allows structural equations in model files to be provided in string form [#1427](https://github.com/econ-ark/HARK/pull/1427)
 - Introduces `HARK.parser' module for parsing configuration files into models [#1427](https://github.com/econ-ark/HARK/pull/1427)
+- Allows construction of shocks with arguments based on mathematical expressions [#1464](https://github.com/econ-ark/HARK/pull/1464)
 
 #### Minor Changes
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -311,6 +311,8 @@ class Lognormal(ContinuousFrozenDistribution):
         mu: Union[float, np.ndarray] = 0.0,
         sigma: Union[float, np.ndarray] = 1.0,
         seed: Optional[int] = 0,
+        mean = None,
+        std = None
     ):
         """
         Create a new Lognormal distribution. If sigma is zero, return a
@@ -324,6 +326,10 @@ class Lognormal(ContinuousFrozenDistribution):
             Standard deviation of underlying normal distribution, by default 1.0
         seed : Optional[int], optional
             Seed for random number generator, by default None
+        mean: optional
+            For alternative mean/std parameterization, the mean of the lognormal distribution
+        std: optional
+            For alternative mean/std parameterization, the standard deviation of the lognormal distribution
 
         Returns
         -------
@@ -342,7 +348,15 @@ class Lognormal(ContinuousFrozenDistribution):
         mu: Union[float, np.ndarray] = 0.0,
         sigma: Union[float, np.ndarray] = 1.0,
         seed: Optional[int] = 0,
+        mean = None,
+        std = None
     ):
+        if mean is not None and sigma is not None:
+            mean_squared = mean**2
+            variance = std**2
+            mu = np.log(mean / (np.sqrt(1.0 + variance / mean_squared)))
+            sigma = np.sqrt(np.log(1.0 + variance / mean_squared))
+
         self.mu = np.asarray(mu)
         self.sigma = np.asarray(sigma)
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -311,8 +311,8 @@ class Lognormal(ContinuousFrozenDistribution):
         mu: Union[float, np.ndarray] = 0.0,
         sigma: Union[float, np.ndarray] = 1.0,
         seed: Optional[int] = 0,
-        mean = None,
-        std = None
+        mean=None,
+        std=None,
     ):
         """
         Create a new Lognormal distribution. If sigma is zero, return a
@@ -348,8 +348,8 @@ class Lognormal(ContinuousFrozenDistribution):
         mu: Union[float, np.ndarray] = 0.0,
         sigma: Union[float, np.ndarray] = 1.0,
         seed: Optional[int] = 0,
-        mean = None,
-        std = None
+        mean=None,
+        std=None,
     ):
         if mean is not None and sigma is not None:
             mean_squared = mean**2

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -122,9 +122,6 @@ def construct_shocks(shock_data, scope):
 
                     dist_args[a] = arg_value
 
-            print(v)
-            print(dist_class)
-            print(dist_args)
             dist = dist_class(**dist_args)
 
             sd[v] = dist

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -228,6 +228,13 @@ class DBlock(Block):
     dynamics: dict = field(default_factory=dict)
     reward: dict = field(default_factory=dict)
 
+    def construct_shocks(self, calibration):
+        """
+        Constructs all shocks given calibration.
+        This method mutates the DBlock.
+        """
+        self.shocks = construct_shocks(self.shocks, calibration)
+
     def discretize(self, disc_params):
         """
         Returns a new DBlock which is a copy of this one, but with shock discretized.
@@ -359,6 +366,13 @@ class RBlock(Block):
     name: str = ""
     description: str = ""
     blocks: List[Block] = field(default_factory=list)
+
+    def construct_shocks(self, calibration):
+        """
+        Construct all shocks given a calibration dictionary.
+        """
+        for b in self.blocks:
+            b.construct_shocks(calibration)
 
     def discretize(self, disc_params):
         """

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -77,6 +77,7 @@ def discretized_shock_dstn(shocks, disc_params):
 
     return all_shock_dstn
 
+
 def construct_shocks(shock_data, scope):
     """
     Returns a dictionary from shock labels to Distributions.
@@ -110,12 +111,14 @@ def construct_shocks(shock_data, scope):
         if isinstance(sd[v], tuple):
             dist_class = sd[v][0]
 
-            dist_args = sd[v][1] # should be a dictionary
+            dist_args = sd[v][1]  # should be a dictionary
 
             for a in dist_args:
                 if isinstance(dist_args[a], str):
                     arg_lambda = math_text_to_lambda(dist_args[a])
-                    arg_value = arg_lambda(*[scope[var] for var in signature(arg_lambda).parameters])
+                    arg_value = arg_lambda(
+                        *[scope[var] for var in signature(arg_lambda).parameters]
+                    )
 
                     dist_args[a] = arg_value
 
@@ -127,6 +130,7 @@ def construct_shocks(shock_data, scope):
             sd[v] = dist
 
     return sd
+
 
 def simulate_dynamics(
     dynamics: Mapping[str, Union[Callable, Control]],

--- a/HARK/models/consumer.py
+++ b/HARK/models/consumer.py
@@ -7,28 +7,26 @@ in the style of Carroll's "Solution Methods for Solving
 Microeconomic Dynamic Stochastic Optimization Problems"
 """
 
-# TODO: Include these in calibration, then construct shocks
-LivPrb = 0.98
-TranShkStd = 0.1
-RiskyStd = 0.1
-
 calibration = {
     "DiscFac": 0.96,
     "CRRA": 2.0,
     "R": 1.03,  # note: this can be overriden by the portfolio dynamics
     "Rfree": 1.03,
     "EqP": 0.02,
-    "LivPrb": LivPrb,
+    "LivPrb": 0.98,
     "PermGroFac": 1.01,
     "BoroCnstArt": None,
+    "TranShkStd" : 0.1,
+    "LivPrb" : 0.98,
+    "RiskyStd" : 0.1
 }
 
 consumption_block = DBlock(
     **{
         "name": "consumption",
         "shocks": {
-            "live": Bernoulli(p=LivPrb),  # Move to tick or mortality block?
-            "theta": MeanOneLogNormal(sigma=TranShkStd),
+            "live": (Bernoulli, {'p' : 'LivPrb'}),  # Move to tick or mortality block?
+            "theta": (MeanOneLogNormal, {'sigma' : 'TranShkStd'}),
         },
         "dynamics": {
             "b": lambda k, R: k * R,
@@ -46,8 +44,8 @@ consumption_block_normalized = DBlock(
     **{
         "name": "consumption normalized",
         "shocks": {
-            "live": Bernoulli(p=LivPrb),  # Move to tick or mortality block?
-            "theta": MeanOneLogNormal(sigma=TranShkStd),
+            "live": (Bernoulli, {"p" : "LivPrb"}),  # Move to tick or mortality block?
+            "theta": (MeanOneLogNormal, {"sigma" : "TranShkStd"}),
         },
         "dynamics": {
             "b": lambda k, R, PermGroFac: k * R / PermGroFac,
@@ -63,9 +61,10 @@ portfolio_block = DBlock(
     **{
         "name": "portfolio",
         "shocks": {
-            "risky_return": Lognormal.from_mean_std(
-                calibration["Rfree"] + calibration["EqP"], RiskyStd
-            )
+            "risky_return": (Lognormal,{
+                "mean" : "Rfree + EqP",
+                "std" : "RiskyStd"
+            })
         },
         "dynamics": {
             "stigma": Control(["a"]),

--- a/HARK/models/consumer.py
+++ b/HARK/models/consumer.py
@@ -17,7 +17,6 @@ calibration = {
     "PermGroFac": 1.01,
     "BoroCnstArt": None,
     "TranShkStd": 0.1,
-    "LivPrb": 0.98,
     "RiskyStd": 0.1,
 }
 

--- a/HARK/models/consumer.py
+++ b/HARK/models/consumer.py
@@ -16,17 +16,17 @@ calibration = {
     "LivPrb": 0.98,
     "PermGroFac": 1.01,
     "BoroCnstArt": None,
-    "TranShkStd" : 0.1,
-    "LivPrb" : 0.98,
-    "RiskyStd" : 0.1
+    "TranShkStd": 0.1,
+    "LivPrb": 0.98,
+    "RiskyStd": 0.1,
 }
 
 consumption_block = DBlock(
     **{
         "name": "consumption",
         "shocks": {
-            "live": (Bernoulli, {'p' : 'LivPrb'}),  # Move to tick or mortality block?
-            "theta": (MeanOneLogNormal, {'sigma' : 'TranShkStd'}),
+            "live": (Bernoulli, {"p": "LivPrb"}),  # Move to tick or mortality block?
+            "theta": (MeanOneLogNormal, {"sigma": "TranShkStd"}),
         },
         "dynamics": {
             "b": lambda k, R: k * R,
@@ -44,8 +44,8 @@ consumption_block_normalized = DBlock(
     **{
         "name": "consumption normalized",
         "shocks": {
-            "live": (Bernoulli, {"p" : "LivPrb"}),  # Move to tick or mortality block?
-            "theta": (MeanOneLogNormal, {"sigma" : "TranShkStd"}),
+            "live": (Bernoulli, {"p": "LivPrb"}),  # Move to tick or mortality block?
+            "theta": (MeanOneLogNormal, {"sigma": "TranShkStd"}),
         },
         "dynamics": {
             "b": lambda k, R, PermGroFac: k * R / PermGroFac,
@@ -61,10 +61,7 @@ portfolio_block = DBlock(
     **{
         "name": "portfolio",
         "shocks": {
-            "risky_return": (Lognormal,{
-                "mean" : "Rfree + EqP",
-                "std" : "RiskyStd"
-            })
+            "risky_return": (Lognormal, {"mean": "Rfree + EqP", "std": "RiskyStd"})
         },
         "dynamics": {
             "stigma": Control(["a"]),

--- a/HARK/simulation/monte_carlo.py
+++ b/HARK/simulation/monte_carlo.py
@@ -14,7 +14,7 @@ from HARK.distribution import (
 )
 from HARK.model import Aggregate
 from HARK.model import DBlock
-from HARK.model import simulate_dynamics
+from HARK.model import construct_shocks, simulate_dynamics
 
 
 def draw_shocks(shocks: Mapping[str, Distribution], conditions: Sequence[int]):
@@ -139,7 +139,11 @@ class AgentTypeMonteCarloSimulator(Simulator):
 
         self.calibration = calibration
         self.block = block
-        self.shocks = block.get_shocks()
+
+        # shocks are exogenous (but for age) but can depend on calibration
+        raw_shocks = block.get_shocks()
+        self.shocks = construct_shocks(raw_shocks, calibration)
+
         self.dynamics = block.get_dynamics()
         self.dr = dr
         self.initial = initial

--- a/HARK/tests/test_model.py
+++ b/HARK/tests/test_model.py
@@ -34,6 +34,7 @@ class test_DBlock(unittest.TestCase):
     def setUp(self):
         self.test_block_A = model.DBlock(**test_block_A_data)
         self.cblock = cons.consumption_block_normalized
+        self.cblock.construct_shocks(cons.calibration)
 
         # prior states relative to the decision, so with realized shocks.
         self.dpre = {"k": 2, "R": 1.05, "PermGroFac": 1.1, "theta": 1, "CRRA": 2}
@@ -98,6 +99,7 @@ class test_RBlock(unittest.TestCase):
         self.assertEqual(len(r_block_tree.get_shocks()), 3)
 
     def test_discretize(self):
+        self.cpp.construct_shocks(cons.calibration)
         cppd = self.cpp.discretize({"theta": {"N": 5}, "risky_return": {"N": 6}})
 
         self.assertEqual(len(cppd.get_shocks()["theta"].pmv), 5)


### PR DESCRIPTION
The "new model files" have had a problem, which is that they depend on fully constructed Distribution objects for each shock. That meant that things like, for example, the standard deviation of the transitory shock could not depend on a calibration dictionary passed in at simulation (let alone solution) time.

This PR fixes this issue.

Now, model files can define shocks with a tuple, e.g. `(Lognormal, {"mean": "Rfree + EqP", "std": "RiskyStd"})`.

When the Monte Carlo simulator is initialized with a calibration dictionary containing values for `Rfree`, `EqP`, and `RiskyStd`, the expressions in the strings are evaluated in the scope of calibration, and these values are passed through to the constructor for `Lognormal`.

Note that since we presume that the shocks are truly exogenous, these expressions need not be evaluated at simulation runtime in that dynamic context. (Though that can be done in principle at the expense of runtime performance).

Tests pass with new 'consumer.py' models that take advantage of this new feature.

p.s. one small change was to provide an alternative means of initializing a Lognormal distribution with mean/std directly, instead of mu/sigma. This could have been implemented in many ways.

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
