### PR TITLE
YAML configuration for consumer portfolio problem, with parser and working tests.

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -18,6 +18,7 @@ Release Date: TBD
 - Allows structural equations in model files to be provided in string form [#1427](https://github.com/econ-ark/HARK/pull/1427)
 - Introduces `HARK.parser' module for parsing configuration files into models [#1427](https://github.com/econ-ark/HARK/pull/1427)
 - Allows construction of shocks with arguments based on mathematical expressions [#1464](https://github.com/econ-ark/HARK/pull/1464)
+- YAML configuration file for the normalized consumption and portolio choice [#1465](https://github.com/econ-ark/HARK/pull/1465)
 
 #### Minor Changes
 

--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -17,6 +17,7 @@ Release Date: TBD
 - Adds a discretize method to DBlocks and RBlocks (#1460)[https://github.com/econ-ark/HARK/pull/1460]
 - Allows structural equations in model files to be provided in string form [#1427](https://github.com/econ-ark/HARK/pull/1427)
 - Introduces `HARK.parser' module for parsing configuration files into models [#1427](https://github.com/econ-ark/HARK/pull/1427)
+- Allows construction of shocks with arguments based on mathematical expressions [#1464](https://github.com/econ-ark/HARK/pull/1464)
 
 #### Minor Changes
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -311,6 +311,8 @@ class Lognormal(ContinuousFrozenDistribution):
         mu: Union[float, np.ndarray] = 0.0,
         sigma: Union[float, np.ndarray] = 1.0,
         seed: Optional[int] = 0,
+        mean = None,
+        std = None
     ):
         """
         Create a new Lognormal distribution. If sigma is zero, return a
@@ -324,6 +326,10 @@ class Lognormal(ContinuousFrozenDistribution):
             Standard deviation of underlying normal distribution, by default 1.0
         seed : Optional[int], optional
             Seed for random number generator, by default None
+        mean: optional
+            For alternative mean/std parameterization, the mean of the lognormal distribution
+        std: optional
+            For alternative mean/std parameterization, the standard deviation of the lognormal distribution
 
         Returns
         -------
@@ -342,7 +348,15 @@ class Lognormal(ContinuousFrozenDistribution):
         mu: Union[float, np.ndarray] = 0.0,
         sigma: Union[float, np.ndarray] = 1.0,
         seed: Optional[int] = 0,
+        mean = None,
+        std = None
     ):
+        if mean is not None and sigma is not None:
+            mean_squared = mean**2
+            variance = std**2
+            mu = np.log(mean / (np.sqrt(1.0 + variance / mean_squared)))
+            sigma = np.sqrt(np.log(1.0 + variance / mean_squared))
+
         self.mu = np.asarray(mu)
         self.sigma = np.asarray(sigma)
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -311,8 +311,8 @@ class Lognormal(ContinuousFrozenDistribution):
         mu: Union[float, np.ndarray] = 0.0,
         sigma: Union[float, np.ndarray] = 1.0,
         seed: Optional[int] = 0,
-        mean = None,
-        std = None
+        mean=None,
+        std=None,
     ):
         """
         Create a new Lognormal distribution. If sigma is zero, return a
@@ -348,8 +348,8 @@ class Lognormal(ContinuousFrozenDistribution):
         mu: Union[float, np.ndarray] = 0.0,
         sigma: Union[float, np.ndarray] = 1.0,
         seed: Optional[int] = 0,
-        mean = None,
-        std = None
+        mean=None,
+        std=None,
     ):
         if mean is not None and sigma is not None:
             mean_squared = mean**2

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -122,9 +122,6 @@ def construct_shocks(shock_data, scope):
 
                     dist_args[a] = arg_value
 
-            print(v)
-            print(dist_class)
-            print(dist_args)
             dist = dist_class(**dist_args)
 
             sd[v] = dist

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -228,6 +228,13 @@ class DBlock(Block):
     dynamics: dict = field(default_factory=dict)
     reward: dict = field(default_factory=dict)
 
+    def construct_shocks(self, calibration):
+        """
+        Constructs all shocks given calibration.
+        This method mutates the DBlock.
+        """
+        self.shocks = construct_shocks(self.shocks, calibration)
+
     def discretize(self, disc_params):
         """
         Returns a new DBlock which is a copy of this one, but with shock discretized.
@@ -359,6 +366,13 @@ class RBlock(Block):
     name: str = ""
     description: str = ""
     blocks: List[Block] = field(default_factory=list)
+
+    def construct_shocks(self, calibration):
+        """
+        Construct all shocks given a calibration dictionary.
+        """
+        for b in self.blocks:
+            b.construct_shocks(calibration)
 
     def discretize(self, disc_params):
         """

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -260,6 +260,10 @@ class DBlock(Block):
             if isinstance(self.dynamics[v], str):
                 self.dynamics[v] = math_text_to_lambda(self.dynamics[v])
 
+        for r in self.reward:
+            if isinstance(self.reward[r], str):
+                self.reward[r] = math_text_to_lambda(self.reward[r])
+
     def get_shocks(self):
         return self.shocks
 

--- a/HARK/model.py
+++ b/HARK/model.py
@@ -77,6 +77,7 @@ def discretized_shock_dstn(shocks, disc_params):
 
     return all_shock_dstn
 
+
 def construct_shocks(shock_data, scope):
     """
     Returns a dictionary from shock labels to Distributions.
@@ -110,12 +111,14 @@ def construct_shocks(shock_data, scope):
         if isinstance(sd[v], tuple):
             dist_class = sd[v][0]
 
-            dist_args = sd[v][1] # should be a dictionary
+            dist_args = sd[v][1]  # should be a dictionary
 
             for a in dist_args:
                 if isinstance(dist_args[a], str):
                     arg_lambda = math_text_to_lambda(dist_args[a])
-                    arg_value = arg_lambda(*[scope[var] for var in signature(arg_lambda).parameters])
+                    arg_value = arg_lambda(
+                        *[scope[var] for var in signature(arg_lambda).parameters]
+                    )
 
                     dist_args[a] = arg_value
 
@@ -127,6 +130,7 @@ def construct_shocks(shock_data, scope):
             sd[v] = dist
 
     return sd
+
 
 def simulate_dynamics(
     dynamics: Mapping[str, Union[Callable, Control]],

--- a/HARK/models/consumer.py
+++ b/HARK/models/consumer.py
@@ -7,28 +7,26 @@ in the style of Carroll's "Solution Methods for Solving
 Microeconomic Dynamic Stochastic Optimization Problems"
 """
 
-# TODO: Include these in calibration, then construct shocks
-LivPrb = 0.98
-TranShkStd = 0.1
-RiskyStd = 0.1
-
 calibration = {
     "DiscFac": 0.96,
     "CRRA": 2.0,
     "R": 1.03,  # note: this can be overriden by the portfolio dynamics
     "Rfree": 1.03,
     "EqP": 0.02,
-    "LivPrb": LivPrb,
+    "LivPrb": 0.98,
     "PermGroFac": 1.01,
     "BoroCnstArt": None,
+    "TranShkStd" : 0.1,
+    "LivPrb" : 0.98,
+    "RiskyStd" : 0.1
 }
 
 consumption_block = DBlock(
     **{
         "name": "consumption",
         "shocks": {
-            "live": Bernoulli(p=LivPrb),  # Move to tick or mortality block?
-            "theta": MeanOneLogNormal(sigma=TranShkStd),
+            "live": (Bernoulli, {'p' : 'LivPrb'}),  # Move to tick or mortality block?
+            "theta": (MeanOneLogNormal, {'sigma' : 'TranShkStd'}),
         },
         "dynamics": {
             "b": lambda k, R: k * R,
@@ -46,8 +44,8 @@ consumption_block_normalized = DBlock(
     **{
         "name": "consumption normalized",
         "shocks": {
-            "live": Bernoulli(p=LivPrb),  # Move to tick or mortality block?
-            "theta": MeanOneLogNormal(sigma=TranShkStd),
+            "live": (Bernoulli, {"p" : "LivPrb"}),  # Move to tick or mortality block?
+            "theta": (MeanOneLogNormal, {"sigma" : "TranShkStd"}),
         },
         "dynamics": {
             "b": lambda k, R, PermGroFac: k * R / PermGroFac,
@@ -63,9 +61,10 @@ portfolio_block = DBlock(
     **{
         "name": "portfolio",
         "shocks": {
-            "risky_return": Lognormal.from_mean_std(
-                calibration["Rfree"] + calibration["EqP"], RiskyStd
-            )
+            "risky_return": (Lognormal,{
+                "mean" : "Rfree + EqP",
+                "std" : "RiskyStd"
+            })
         },
         "dynamics": {
             "stigma": Control(["a"]),

--- a/HARK/models/consumer.py
+++ b/HARK/models/consumer.py
@@ -17,7 +17,6 @@ calibration = {
     "PermGroFac": 1.01,
     "BoroCnstArt": None,
     "TranShkStd": 0.1,
-    "LivPrb": 0.98,
     "RiskyStd": 0.1,
 }
 

--- a/HARK/models/consumer.py
+++ b/HARK/models/consumer.py
@@ -16,17 +16,17 @@ calibration = {
     "LivPrb": 0.98,
     "PermGroFac": 1.01,
     "BoroCnstArt": None,
-    "TranShkStd" : 0.1,
-    "LivPrb" : 0.98,
-    "RiskyStd" : 0.1
+    "TranShkStd": 0.1,
+    "LivPrb": 0.98,
+    "RiskyStd": 0.1,
 }
 
 consumption_block = DBlock(
     **{
         "name": "consumption",
         "shocks": {
-            "live": (Bernoulli, {'p' : 'LivPrb'}),  # Move to tick or mortality block?
-            "theta": (MeanOneLogNormal, {'sigma' : 'TranShkStd'}),
+            "live": (Bernoulli, {"p": "LivPrb"}),  # Move to tick or mortality block?
+            "theta": (MeanOneLogNormal, {"sigma": "TranShkStd"}),
         },
         "dynamics": {
             "b": lambda k, R: k * R,
@@ -44,8 +44,8 @@ consumption_block_normalized = DBlock(
     **{
         "name": "consumption normalized",
         "shocks": {
-            "live": (Bernoulli, {"p" : "LivPrb"}),  # Move to tick or mortality block?
-            "theta": (MeanOneLogNormal, {"sigma" : "TranShkStd"}),
+            "live": (Bernoulli, {"p": "LivPrb"}),  # Move to tick or mortality block?
+            "theta": (MeanOneLogNormal, {"sigma": "TranShkStd"}),
         },
         "dynamics": {
             "b": lambda k, R, PermGroFac: k * R / PermGroFac,
@@ -61,10 +61,7 @@ portfolio_block = DBlock(
     **{
         "name": "portfolio",
         "shocks": {
-            "risky_return": (Lognormal,{
-                "mean" : "Rfree + EqP",
-                "std" : "RiskyStd"
-            })
+            "risky_return": (Lognormal, {"mean": "Rfree + EqP", "std": "RiskyStd"})
         },
         "dynamics": {
             "stigma": Control(["a"]),

--- a/HARK/models/consumer.yaml
+++ b/HARK/models/consumer.yaml
@@ -31,30 +31,13 @@ blocks:
 
         reward:
             u: c ** (1 - CRRA) / (1 - CRRA)
-
-
-#portfolio_block = DBlock(
-#    **{
-#        "name": "portfolio",
-#        "shocks": {
-#            "risky_return": (Lognormal, {"mean": "Rfree + EqP", "std": "RiskyStd"})
-#        },
-#        "dynamics": {
-#            "stigma": Control(["a"]),
-#            "R": lambda stigma, Rfree, risky_return: Rfree
-#            + (risky_return - Rfree) * stigma,
-#        },
-#    }
-#)
-
-#tick_block = DBlock(
-#    **{
-#        "name": "tick",
-#        "dynamics": {
-#            "k": lambda a: a,
-#        },
-#    }
-#)
-
-#cons_problem = RBlock(blocks=[consumption_block, tick_block])
-#cons_portfolio_problem = RBlock(blocks=[consumption_block, portfolio_block, tick_block])
+    - &portfolio_choice
+        name: portfolio choice
+        shocks:
+            risky_return: !Lognormal
+                mean: Rfree + EqP
+                std: RiskyStd
+            dynamics:
+                stigma: !Control
+                    info: a
+                R: Rfree + (risky_return - Rfree) * stigma

--- a/HARK/models/consumer.yaml
+++ b/HARK/models/consumer.yaml
@@ -1,0 +1,60 @@
+#
+# A YAML configuration file for the consumption portfolio problem blocks.
+#
+
+calibration:
+    DiscFac: 0.96
+    CRRA: 2.0
+    R: 1.03 # can be overriden by portfolio dynamics
+    Rfree: 1.03
+    EqP: 0.02
+    LivPrb: 0.98
+    PermGroFac: 1.01
+    BoroCnstArt: None
+    TranShkStd: 0.1
+    RiskyStd: 0.1
+
+blocks:
+    - &cons_normalized
+        name: consumption normalized
+        shocks:
+            live: !Bernoulli
+                p: LivPrb
+            theta: !MeanOneLogNormal
+                sigma: TranShkStd
+        dynamics:
+            b: k * R / PermGroFac
+            m: b + theta
+            c: !Control
+                info: m
+            a: m - c
+
+        reward: 
+            u: c ** (1 - CRRA) / (1 - CRRA)
+
+
+#portfolio_block = DBlock(
+#    **{
+#        "name": "portfolio",
+#        "shocks": {
+#            "risky_return": (Lognormal, {"mean": "Rfree + EqP", "std": "RiskyStd"})
+#        },
+#        "dynamics": {
+#            "stigma": Control(["a"]),
+#            "R": lambda stigma, Rfree, risky_return: Rfree
+#            + (risky_return - Rfree) * stigma,
+#        },
+#    }
+#)
+
+#tick_block = DBlock(
+#    **{
+#        "name": "tick",
+#        "dynamics": {
+#            "k": lambda a: a,
+#        },
+#    }
+#)
+
+#cons_problem = RBlock(blocks=[consumption_block, tick_block])
+#cons_portfolio_problem = RBlock(blocks=[consumption_block, portfolio_block, tick_block])

--- a/HARK/models/consumer.yaml
+++ b/HARK/models/consumer.yaml
@@ -29,7 +29,7 @@ blocks:
                 info: m
             a: m - c
 
-        reward: 
+        reward:
             u: c ** (1 - CRRA) / (1 - CRRA)
 
 

--- a/HARK/parser.py
+++ b/HARK/parser.py
@@ -1,5 +1,16 @@
+from HARK.distribution import Bernoulli, Lognormal, MeanOneLogNormal
 from sympy.utilities.lambdify import lambdify
 from sympy.parsing.sympy_parser import parse_expr
+import yaml
+
+
+class ControlToken:
+    """
+    Represents a parsed Control variable.
+    """
+
+    def __init__(self, args):
+        pass
 
 
 class Expression:
@@ -17,6 +28,14 @@ class Expression:
         return lambdify(list(self.expr.free_symbols), self.expr, "numpy")
 
 
+def tuple_constructor_from_class(cls):
+    def constructor(loader, node):
+        value = loader.construct_mapping(node)
+        return (cls, value)
+
+    return constructor
+
+
 def math_text_to_lambda(text):
     """
     Returns a function represented by the given mathematical text.
@@ -24,3 +43,25 @@ def math_text_to_lambda(text):
     expr = parse_expr(text)
     func = lambdify(list(expr.free_symbols), expr, "numpy")
     return func
+
+
+def harklang_loader():
+    """Add constructors to PyYAML loader."""
+    loader = yaml.SafeLoader
+    yaml.SafeLoader.add_constructor(
+        "!Bernoulli", tuple_constructor_from_class(Bernoulli)
+    )
+    yaml.SafeLoader.add_constructor(
+        "!MeanOneLogNormal", tuple_constructor_from_class(MeanOneLogNormal)
+    )
+    yaml.SafeLoader.add_constructor(
+        "!Lognormal", tuple_constructor_from_class(Lognormal)
+    )
+    yaml.SafeLoader.add_constructor(
+        "!Control", tuple_constructor_from_class(ControlToken)
+    )
+
+    return loader
+
+
+########################################################################

--- a/HARK/parser.py
+++ b/HARK/parser.py
@@ -46,7 +46,10 @@ def math_text_to_lambda(text):
 
 
 def harklang_loader():
-    """Add constructors to PyYAML loader."""
+    """
+    A PyYAML loader that supports tags for HARKLang,
+    such as random variables and model tags.
+    """
     loader = yaml.SafeLoader
     yaml.SafeLoader.add_constructor(
         "!Bernoulli", tuple_constructor_from_class(Bernoulli)
@@ -62,6 +65,3 @@ def harklang_loader():
     )
 
     return loader
-
-
-########################################################################

--- a/HARK/simulation/monte_carlo.py
+++ b/HARK/simulation/monte_carlo.py
@@ -14,7 +14,7 @@ from HARK.distribution import (
 )
 from HARK.model import Aggregate
 from HARK.model import DBlock
-from HARK.model import simulate_dynamics
+from HARK.model import construct_shocks, simulate_dynamics
 
 
 def draw_shocks(shocks: Mapping[str, Distribution], conditions: Sequence[int]):
@@ -139,7 +139,11 @@ class AgentTypeMonteCarloSimulator(Simulator):
 
         self.calibration = calibration
         self.block = block
-        self.shocks = block.get_shocks()
+
+        # shocks are exogenous (but for age) but can depend on calibration
+        raw_shocks = block.get_shocks()
+        self.shocks = construct_shocks(raw_shocks, calibration)
+
         self.dynamics = block.get_dynamics()
         self.dr = dr
         self.initial = initial

--- a/HARK/tests/test_model.py
+++ b/HARK/tests/test_model.py
@@ -34,6 +34,7 @@ class test_DBlock(unittest.TestCase):
     def setUp(self):
         self.test_block_A = model.DBlock(**test_block_A_data)
         self.cblock = cons.consumption_block_normalized
+        self.cblock.construct_shocks(cons.calibration)
 
         # prior states relative to the decision, so with realized shocks.
         self.dpre = {"k": 2, "R": 1.05, "PermGroFac": 1.1, "theta": 1, "CRRA": 2}
@@ -98,6 +99,7 @@ class test_RBlock(unittest.TestCase):
         self.assertEqual(len(r_block_tree.get_shocks()), 3)
 
     def test_discretize(self):
+        self.cpp.construct_shocks(cons.calibration)
         cppd = self.cpp.discretize({"theta": {"N": 5}, "risky_return": {"N": 6}})
 
         self.assertEqual(len(cppd.get_shocks()["theta"].pmv), 5)

--- a/HARK/tests/test_parser.py
+++ b/HARK/tests/test_parser.py
@@ -1,0 +1,51 @@
+import os
+import unittest
+
+
+import HARK.parser as parser
+import yaml
+
+
+class test_consumption_parsing(unittest.TestCase):
+    def setUp(self):
+        this_file_path = os.path.dirname(__file__)
+        consumer_yaml_path = os.path.join(this_file_path, "../models/consumer.yaml")
+
+        self.consumer_yaml_file = open(consumer_yaml_path, "r")
+
+    def test_parse(self):
+        self.consumer_yaml_file
+
+        config = yaml.load(self.consumer_yaml_file, Loader=parser.harklang_loader())
+        pass
+
+        """
+        try:
+            config = yaml.load(open('perfect_foresight_full_experimental.yaml', 'r'), Loader= get_loader())
+
+            # data is copied
+            assert config['model']['blocks']['consumption'] == config['model']['strategies'][1]['block']
+            # data is maintained once in memory and referenced in both places
+            assert config['model']['blocks']['consumption'] is config['model']['strategies'][1]['block']
+
+            # object created by parser
+            c1 = config['model']['blocks']['consumption']['dynamics']['c']
+            c2 = config['model']['strategies'][1]['block']['dynamics']['c']
+
+            # objects are equal
+            assert c1 == c2
+            # objects are identical in memory; the reference is shared.
+                assert c1 is c2
+
+            a_str = config['model']['blocks']['consumption']['dynamics']['a']
+            a_expr = parse_expr(a_str)
+            a_func = lambdify(list(a_expr.free_symbols), a_expr, "numpy")
+
+            m = np.random.random(100)
+            c = np.random.random(100)
+
+            #import pdb; pdb.set_trace()
+
+        except yaml.YAMLError as exc:
+            print("Error in configuration file:", exc)
+        """

--- a/HARK/tests/test_parser.py
+++ b/HARK/tests/test_parser.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-
+import HARK.model as model
 import HARK.parser as parser
 import yaml
 
@@ -17,35 +17,12 @@ class test_consumption_parsing(unittest.TestCase):
         self.consumer_yaml_file
 
         config = yaml.load(self.consumer_yaml_file, Loader=parser.harklang_loader())
-        pass
 
-        """
-        try:
-            config = yaml.load(open('perfect_foresight_full_experimental.yaml', 'r'), Loader= get_loader())
+        self.assertEqual(config['calibration']['DiscFac'], 0.96)
+        self.assertEqual(config['blocks'][0]['name'], 'consumption normalized')
 
-            # data is copied
-            assert config['model']['blocks']['consumption'] == config['model']['strategies'][1]['block']
-            # data is maintained once in memory and referenced in both places
-            assert config['model']['blocks']['consumption'] is config['model']['strategies'][1]['block']
-
-            # object created by parser
-            c1 = config['model']['blocks']['consumption']['dynamics']['c']
-            c2 = config['model']['strategies'][1]['block']['dynamics']['c']
-
-            # objects are equal
-            assert c1 == c2
-            # objects are identical in memory; the reference is shared.
-                assert c1 is c2
-
-            a_str = config['model']['blocks']['consumption']['dynamics']['a']
-            a_expr = parse_expr(a_str)
-            a_func = lambdify(list(a_expr.free_symbols), a_expr, "numpy")
-
-            m = np.random.random(100)
-            c = np.random.random(100)
-
-            #import pdb; pdb.set_trace()
-
-        except yaml.YAMLError as exc:
-            print("Error in configuration file:", exc)
-        """
+        ## construct and test the block
+        cons_norm_block = model.DBlock(**config['blocks'][0])
+        cons_norm_block.construct_shocks(config['calibration'])
+        cons_norm_block.discretize({"theta": {"N": 5}})
+        self.assertEqual(cons_norm_block.calc_reward({"c": 1, "CRRA": 2})["u"], -1.0)

--- a/HARK/tests/test_parser.py
+++ b/HARK/tests/test_parser.py
@@ -18,11 +18,16 @@ class test_consumption_parsing(unittest.TestCase):
 
         config = yaml.load(self.consumer_yaml_file, Loader=parser.harklang_loader())
 
-        self.assertEqual(config['calibration']['DiscFac'], 0.96)
-        self.assertEqual(config['blocks'][0]['name'], 'consumption normalized')
+        self.assertEqual(config["calibration"]["DiscFac"], 0.96)
+        self.assertEqual(config["blocks"][0]["name"], "consumption normalized")
 
-        ## construct and test the block
-        cons_norm_block = model.DBlock(**config['blocks'][0])
-        cons_norm_block.construct_shocks(config['calibration'])
+        ## construct and test the consumption block
+        cons_norm_block = model.DBlock(**config["blocks"][0])
+        cons_norm_block.construct_shocks(config["calibration"])
         cons_norm_block.discretize({"theta": {"N": 5}})
         self.assertEqual(cons_norm_block.calc_reward({"c": 1, "CRRA": 2})["u"], -1.0)
+
+        ## construct and test the portfolio block
+        portfolio_block = model.DBlock(**config["blocks"][1])
+        portfolio_block.construct_shocks(config["calibration"])
+        portfolio_block.discretize({"risky_return": {"N": 5}})

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,7 @@ networkx>=3
 numba<0.60.0
 numpy>=1.23
 pandas>=1.5
+pyyaml>=6.0
 quantecon
 scipy>=1.10
 seaborn>=0.12


### PR DESCRIPTION
This PR aims to provide a YAML configuration file for the blocks for the normalized consumer problem as well as the portfolio choice extension. It is work towards #1373 

It also aims to provide a working parser, which can produce well-formed block objects that are compatible with the Monte Carlo simulator.

This PR builds on #1464

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
