### PR TITLE
Remove employment accounting lines

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -22,6 +22,7 @@ Release Date: TBD
 
 - Fixes bug in `AgentPopulation` that caused discretization of distributions to not work. [1275](https://github.com/econ-ark/HARK/pull/1275)
 - Adds support for distributions, booleans, and callables as parameters in the `Parameters` class. [1387](https://github.com/econ-ark/HARK/pull/1387)
+- Removes a specific way of accounting for ``employment'' in the idiosyncratic-shocks income process. [1473](https://github.com/econ-ark/HARK/pull/1473)
 
 ### 0.15.1
 

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -2045,8 +2045,6 @@ class IndShockConsumerType(PerfForesightConsumerType):
             TranShkNow[newborn] = 1.0
 
         # Store the shocks in self
-        self.EmpNow = np.ones(self.AgentCount, dtype=bool)
-        self.EmpNow[TranShkNow == self.IncUnemp] = False
         self.shocks["PermShk"] = PermShkNow
         self.shocks["TranShk"] = TranShkNow
 


### PR DESCRIPTION
Two lines that were added to the income process of consindshock for `cstwMPC` are now causing trouble. See https://github.com/econ-ark/HARK/issues/984 and https://github.com/econ-ark/HARK/issues/1182.

This PR removes those lines. This does not break anything _within_ HARK itself.

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
