### PR TITLE
Specify bounds on multivariate distributions

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -25,6 +25,7 @@ Release Date: TBD
 - Fixes bug in `AgentPopulation` that caused discretization of distributions to not work. [1275](https://github.com/econ-ark/HARK/pull/1275)
 - Adds support for distributions, booleans, and callables as parameters in the `Parameters` class. [1387](https://github.com/econ-ark/HARK/pull/1387)
 - Removes a specific way of accounting for ``employment'' in the idiosyncratic-shocks income process. [1473](https://github.com/econ-ark/HARK/pull/1473)
+- Improved tracking of the bounds of support for distributions, and (some) solvers now respect those bounds when computing the "worst outcome". [1479](https://github.com/econ-ark/HARK/pull/1479)
 
 ### 0.15.1
 

--- a/HARK/Calibration/Income/IncomeProcesses.py
+++ b/HARK/Calibration/Income/IncomeProcesses.py
@@ -194,7 +194,12 @@ class MixtureTranIncShk_HANK(DiscreteDistribution):
         # Rescale the transitory shock values to account for new features
         TranShkMean_temp = (1.0 - tax_rate) * labor * wage
         dstn_approx.atoms *= TranShkMean_temp
-        super().__init__(pmv=dstn_approx.pmv, atoms=dstn_approx.atoms, seed=seed)
+        super().__init__(
+            pmv=dstn_approx.pmv,
+            atoms=dstn_approx.atoms,
+            limit=dstn_approx.limit,
+            seed=seed,
+        )
 
 
 class BufferStockIncShkDstn(DiscreteDistributionLabeled):
@@ -340,6 +345,7 @@ class IncShkDstn_HANK(DiscreteDistributionLabeled):
             var_names=["PermShk", "TranShk"],
             pmv=joint_dstn.pmv,
             atoms=joint_dstn.atoms,
+            limit=joint_dstn.limit,
             seed=seed,
         )
 

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -404,7 +404,10 @@ def calc_worst_inc_prob(inc_shk_dstn):
     probs = inc_shk_dstn.pmv
     perm, tran = inc_shk_dstn.atoms
     income = perm * tran
-    worst_inc = np.min(income)
+    try:
+        worst_inc = np.prod(inc_shk_dstn.limit['infimum'])
+    except:
+        worst_inc = np.min(income)
     return np.sum(probs[income == worst_inc])
 
 
@@ -417,9 +420,16 @@ def calc_boro_const_nat(m_nrm_min_next, inc_shk_dstn, rfree, perm_gro_fac):
         rfree (float): Risk free interest factor.
         perm_gro_fac (float): Permanent income growth factor.
     """
-    perm, tran = inc_shk_dstn.atoms
-    temp_fac = (perm_gro_fac * np.min(perm)) / rfree
-    return (m_nrm_min_next - np.min(tran)) * temp_fac
+    try:
+        perm_min, tran_min = inc_shk_dstn.limit['infimum']
+    except:
+        perm, tran = inc_shk_dstn.atoms
+        perm_min = np.min(perm)
+        tran_min = np.min(tran)
+        
+    temp_fac = (perm_gro_fac * perm_min) / rfree
+    boro_cnst_nat = (m_nrm_min_next - tran_min) * temp_fac
+    return boro_cnst_nat
 
 
 def calc_m_nrm_min(boro_const_art, boro_const_nat):

--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -405,7 +405,7 @@ def calc_worst_inc_prob(inc_shk_dstn):
     perm, tran = inc_shk_dstn.atoms
     income = perm * tran
     try:
-        worst_inc = np.prod(inc_shk_dstn.limit['infimum'])
+        worst_inc = np.prod(inc_shk_dstn.limit["infimum"])
     except:
         worst_inc = np.min(income)
     return np.sum(probs[income == worst_inc])
@@ -421,12 +421,12 @@ def calc_boro_const_nat(m_nrm_min_next, inc_shk_dstn, rfree, perm_gro_fac):
         perm_gro_fac (float): Permanent income growth factor.
     """
     try:
-        perm_min, tran_min = inc_shk_dstn.limit['infimum']
+        perm_min, tran_min = inc_shk_dstn.limit["infimum"]
     except:
         perm, tran = inc_shk_dstn.atoms
         perm_min = np.min(perm)
         tran_min = np.min(tran)
-        
+
     temp_fac = (perm_gro_fac * perm_min) / rfree
     boro_cnst_nat = (m_nrm_min_next - tran_min) * temp_fac
     return boro_cnst_nat

--- a/HARK/ConsumptionSaving/tests/test_ConsNewKeynesianModel.py
+++ b/HARK/ConsumptionSaving/tests/test_ConsNewKeynesianModel.py
@@ -39,7 +39,7 @@ class test_Transition_Matrix_Methods(unittest.TestCase):
         AggC = np.dot(gridc.flatten(), vecDstn)  # Aggregate Consumption
         AggA = np.dot(grida.flatten(), vecDstn)  # Aggregate Assets
 
-        self.assertAlmostEqual(AggA[0], 0.82984, places=4)
+        self.assertAlmostEqual(AggA[0], 0.82960, places=4)
         self.assertAlmostEqual(AggC[0], 1.00780, places=4)
 
 
@@ -52,6 +52,6 @@ class test_Jacobian_methods(unittest.TestCase):
         Agent.compute_steady_state()
         CJAC_Perm, AJAC_Perm = Agent.calc_jacobian("PermShkStd", 50)
 
-        self.assertAlmostEqual(CJAC_Perm.T[30][29], -0.10503, places=HARK_PRECISION)
+        self.assertAlmostEqual(CJAC_Perm.T[30][29], -0.10508, places=HARK_PRECISION)
         self.assertAlmostEqual(CJAC_Perm.T[30][30], 0.10316, places=HARK_PRECISION)
         self.assertAlmostEqual(CJAC_Perm.T[30][31], 0.09059, places=HARK_PRECISION)

--- a/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
+++ b/HARK/ConsumptionSaving/tests/test_IndShockConsumerType.py
@@ -50,17 +50,17 @@ class testIndShockConsumerType(unittest.TestCase):
 
         self.assertAlmostEqual(
             LifecycleExample.solution[0].cFunc(1).tolist(),
-            0.75062,
+            0.75074,
             places=HARK_PRECISION,
         )
         self.assertAlmostEqual(
             LifecycleExample.solution[1].cFunc(1).tolist(),
-            0.75864,
+            0.75876,
             places=HARK_PRECISION,
         )
         self.assertAlmostEqual(
             LifecycleExample.solution[2].cFunc(1).tolist(),
-            0.76812,
+            0.76824,
             places=HARK_PRECISION,
         )
 
@@ -223,13 +223,15 @@ class testIndShockConsumerTypeExample(unittest.TestCase):
         IndShockExample.solve()
 
         self.assertAlmostEqual(
-            IndShockExample.solution[0].mNrmStE, 1.54882, places=HARK_PRECISION
+            IndShockExample.solution[0].mNrmStE, 1.54765, places=HARK_PRECISION
         )
-        self.assertAlmostEqual(
-            IndShockExample.solution[0].cFunc.functions[0].x_list[0],
-            -0.25018,
-            places=HARK_PRECISION,
-        )
+        # self.assertAlmostEqual(
+        #    IndShockExample.solution[0].cFunc.functions[0].x_list[0],
+        #    -0.25018,
+        #    places=HARK_PRECISION,
+        # )
+        # This test is commented out because it was trivialized by revisions to the "worst income shock" code.
+        # The bottom x value of the unconstrained consumption function will definitely be zero, so this is pointless.
 
         IndShockExample.track_vars = ["aNrm", "mNrm", "cNrm", "pLvl"]
         IndShockExample.initialize_sim()
@@ -297,7 +299,7 @@ class testIndShockConsumerTypeLifecycle(unittest.TestCase):
 
         self.assertAlmostEqual(
             LifecycleExample.solution[5].cFunc(3).tolist(),
-            2.12998,
+            2.13004,
             places=HARK_PRECISION,
         )
 
@@ -371,7 +373,7 @@ class testIndShockConsumerTypeCyclical(unittest.TestCase):
 
         self.assertAlmostEqual(
             CyclicalExample.solution[3].cFunc(3).tolist(),
-            1.59584,
+            1.59597,
             places=HARK_PRECISION,
         )
 
@@ -379,7 +381,7 @@ class testIndShockConsumerTypeCyclical(unittest.TestCase):
         CyclicalExample.simulate()
 
         self.assertAlmostEqual(
-            CyclicalExample.state_now["aLvl"][1], 3.32431, places=HARK_PRECISION
+            CyclicalExample.state_now["aLvl"][1], 3.31950, places=HARK_PRECISION
         )
 
 

--- a/HARK/ConsumptionSaving/tests/test_modelcomparisons.py
+++ b/HARK/ConsumptionSaving/tests/test_modelcomparisons.py
@@ -47,7 +47,7 @@ class Compare_PerfectForesight_and_Infinite(unittest.TestCase):
         test_dictionary["UnempPrb"] = 0.0
         test_dictionary["T_cycle"] = 1
         test_dictionary["T_retire"] = 0
-        test_dictionary["BoroCnstArt"] = None
+        test_dictionary["BoroCnstArt"] = 0.0
 
         InfiniteType = IndShockConsumerType(**test_dictionary)
         InfiniteType.cycles = 0
@@ -79,7 +79,7 @@ class Compare_PerfectForesight_and_Infinite(unittest.TestCase):
                 m
             ) - self.InfiniteType.cFunc[0](m)
 
-        points = np.arange(0.5, mNrmMinInf + aXtraMin, mNrmMinInf + aXtraMax)
+        points = np.arange(0.5, mNrmMinInf + aXtraMax, mNrmMinInf + aXtraMin)
         difference = diffFunc(points)
         max_difference = np.max(np.abs(difference))
 

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -848,8 +848,8 @@ class DiscreteDistribution(Distribution):
         self.atoms = np.atleast_2d(atoms)
         if limit is None:
             limit = {
-                "infimum": np.min(self.atoms, axis=-1, keepdims=True),
-                "supremum": np.max(self.atoms, axis=-1, keepdims=True),
+                "infimum": np.min(self.atoms, axis=-1),
+                "supremum": np.max(self.atoms, axis=-1),
             }
         self.limit = limit
 
@@ -1132,8 +1132,8 @@ class DiscreteDistributionLabeled(DiscreteDistribution):
         attrs = {} if attrs is None else attrs
         if limit is None:
             limit = {
-                "infimum": np.min(self.atoms, axis=-1, keepdims=True),
-                "supremum": np.max(self.atoms, axis=-1, keepdims=True),
+                "infimum": np.min(self.atoms, axis=-1),
+                "supremum": np.max(self.atoms, axis=-1),
             }
             self.limit = limit
         attrs.update(limit)

--- a/HARK/distribution.py
+++ b/HARK/distribution.py
@@ -603,8 +603,8 @@ class Uniform(ContinuousFrozenDistribution):
             stats.uniform, loc=self.bot, scale=self.top - self.bot, seed=seed
         )
 
-        self.infimum = self.bot
-        self.supremum = self.top
+        self.infimum = np.array([self.bot])
+        self.supremum = np.array([self.top])
 
     def _approx_equiprobable(self, N, endpoints=False):
         """
@@ -635,7 +635,12 @@ class Uniform(ContinuousFrozenDistribution):
             atoms = np.concatenate(([self.bot], atoms, [self.top]))
             pmv = np.concatenate(([0.0], pmv, [0.0]))
 
-        limit = {"dist": self, "method": "equiprobable", "N": N, "endpoints": endpoints}
+        limit = {
+            "dist": self,
+            "method": "equiprobable",
+            "N": N,
+            "endpoints": endpoints,
+        }
 
         return DiscreteDistribution(
             pmv,
@@ -841,6 +846,11 @@ class DiscreteDistribution(Distribution):
 
         self.pmv = np.asarray(pmv)
         self.atoms = np.atleast_2d(atoms)
+        if limit is None:
+            limit = {
+                "infimum": np.min(self.atoms, axis=-1, keepdims=True),
+                "supremum": np.max(self.atoms, axis=-1, keepdims=True),
+            }
         self.limit = limit
 
         # Check that pmv and atoms have compatible dimensions.
@@ -1120,7 +1130,12 @@ class DiscreteDistributionLabeled(DiscreteDistribution):
             )
 
         attrs = {} if attrs is None else attrs
-        limit = {} if limit is None else limit
+        if limit is None:
+            limit = {
+                "infimum": np.min(self.atoms, axis=-1, keepdims=True),
+                "supremum": np.max(self.atoms, axis=-1, keepdims=True),
+            }
+            self.limit = limit
         attrs.update(limit)
         attrs["name"] = name
 


### PR DESCRIPTION
The `limit` attribute of DiscreteDistribution instances links to the underlying continuous distribution from which it was generated, and also has information about the discretization parameters. There's still some work to be done on *standardizing* the `limit` dictionary, but its functionality has now been extended to include `infimum` and `supremum` entries, and for these to be handled correctly by `combine_independent_discrete_dstns`. The information in these entries (the bounds on each dimension of the distribution) is now used by ConsIndShock's solver to find the "worst income shock realization".

As described in the commit notes, this doesn't actually affect the consumption function solution very much. The user needs to both add aXtra points *very* close to zero **and** include a tiny point mass at the infimum for the consumption function to actually have gridpoints on the "almost constrained" portion.

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
