### PR TITLE
Start solver from arbitrary solution object

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -36,6 +36,7 @@ Release Date: TBD
 - Expands functionality of Cobb-Douglas aggregator for CRRA utility. [#1363](https://github.com/econ-ark/HARK/pull/1363)
 - Adds a new function for using Tauchen's method to approximate an AR1 process. [#1521](https://github.com/econ-ark/HARK/pull/1521)
 - Adds additional functionality to the CubicHermiteInterp class, imported from scipy.interpolate. [#1020](https://github.com/econ-ark/HARK/pull/1020/)
+- Allows users to pass a generic solution object to agent solvers to be used as the initial condition of backward induction. [#1543](https://github.com/econ-ark/HARK/pull/1543)
 
 ### 0.15.1
 

--- a/HARK/core.py
+++ b/HARK/core.py
@@ -908,7 +908,7 @@ class AgentType(Model):
             self.__dict__[parameter].append(solution_t.__dict__[parameter])
         self.add_to_time_vary(parameter)
 
-    def solve(self, verbose=False, presolve=True):
+    def solve(self, verbose=False, presolve=True, from_solution=None):
         """
         Solve the model for this instance of an agent type by backward induction.
         Loops through the sequence of one period problems, passing the solution
@@ -935,7 +935,7 @@ class AgentType(Model):
             if presolve:
                 self.pre_solve()  # Do pre-solution stuff
             self.solution = solve_agent(
-                self, verbose
+                self, verbose, from_solution
             )  # Solve the model by backward induction
             self.post_solve()  # Do post-solution stuff
 
@@ -1508,7 +1508,7 @@ class AgentType(Model):
             self.history[var_name].fill(np.nan)
 
 
-def solve_agent(agent, verbose):
+def solve_agent(agent, verbose, from_solution=None):
     """
     Solve the dynamic model for one agent type
     using backwards induction.
@@ -1535,13 +1535,18 @@ def solve_agent(agent, verbose):
     # Check to see whether this is an (in)finite horizon problem
     cycles_left = agent.cycles  # NOQA
     infinite_horizon = cycles_left == 0  # NOQA
+
+    if from_solution is None:
+        solution_last = agent.solution_terminal  # NOQA
+    else:
+        solution_last = from_solution
+
     # Initialize the solution, which includes the terminal solution if it's not a pseudo-terminal period
     solution = []
     if not agent.pseudo_terminal:
-        solution.insert(0, deepcopy(agent.solution_terminal))
+        solution.insert(0, deepcopy(solution_last))
 
     # Initialize the process, then loop over cycles
-    solution_last = agent.solution_terminal  # NOQA
     go = True  # NOQA
     completed_cycles = 0  # NOQA
     max_cycles = 5000  # NOQA  - escape clause

--- a/HARK/core.py
+++ b/HARK/core.py
@@ -1525,6 +1525,9 @@ def solve_agent(agent, verbose, from_solution=None):
         is to be solved.
     verbose : boolean
         If True, solution progress is printed to screen (when cycles != 1).
+    from_solution: Solution
+        If different from None, will be used as the starting point of backward
+        induction, instead of self.solution_terminal
 
     Returns
     -------

--- a/HARK/core.py
+++ b/HARK/core.py
@@ -920,6 +920,9 @@ class AgentType(Model):
             If True, solution progress is printed to screen. Default False.
         presolve : bool, optional
             If True (default), the pre_solve method is run before solving.
+        from_solution: Solution
+            If different from None, will be used as the starting point of backward
+            induction, instead of self.solution_terminal
 
         Returns
         -------

--- a/HARK/tests/test_core.py
+++ b/HARK/tests/test_core.py
@@ -252,32 +252,28 @@ class TestParameters:
 
 
 class TestSolveFrom(unittest.TestCase):
-
     def shorten_params(self, params, length):
-
         par = deepcopy(params)
         for key in params.keys():
             if isinstance(params[key], list):
                 par[key] = params[key][:length]
-        par['T_cycle'] = length
+        par["T_cycle"] = length
         return par
 
     def setUp(self):
-        
         # Create a 3-period parametrization of the IndShockConsumerType model
         self.params = init_idiosyncratic_shocks.copy()
         self.params.update(
             {
-                'T_cycle' : 3,
-                'PermGroFac' : [1.05, 1.10, 1.3],
-                'LivPrb' : [0.95, 0.9, 0.85],
-                'TranShkStd' : [0.1]*3,
-                'PermShkStd' : [0.1]*3,
+                "T_cycle": 3,
+                "PermGroFac": [1.05, 1.10, 1.3],
+                "LivPrb": [0.95, 0.9, 0.85],
+                "TranShkStd": [0.1] * 3,
+                "PermShkStd": [0.1] * 3,
             }
         )
 
     def test_solve_from(self):
-
         # Create an IndShockConsumerType agent
         agent = IndShockConsumerType(**self.params)
         # Solve the model
@@ -291,5 +287,3 @@ class TestSolveFrom(unittest.TestCase):
         # The solutions (up to 2) must be the same
         for t, s2 in enumerate(agent_2.solution):
             self.assertEqual(s2.distance(agent.solution[t]), 0.0)
-        
-


### PR DESCRIPTION
Sometimes (e.g. when using the Fake News method to get Jacobians), it is useful to solve a model backwards starting from a solution object that one already has in hand.

For instance, imagine an infinite horizon model. I have already computed the steady state solution `ss_sol`. Now I want to know what the solution would be if I gave the model the sequence of inputs `[R_ss, R_ss, R_ss + dx, R_ss, R_ss, ...]`. I can solve my problem by doing backward induction on a three-period model with inputs `[R_ss, R_ss, R_ss + dx]` that takes `ss_sol` as its continuation value/ terminal solution.

This PR adds exactly this functionality, which I have had in my private branches for a while and has been very useful.

I imagine you can somehow already do this in HARK, manually overriding `solution_terminal`. @wdu9 managed to do this. But I think those manual overrides are hacky and it is also hard to know when `update_solution_terminal()` will be called and re-override the solution. I found this implementation clearer and more convenient.

<!--- Put an `x` in all the boxes that apply: -->

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [x] Update CHANGELOG.md with major/minor changes.
