### PR TITLE
Small fixes to simulator methods

### DIFF
--- a/HARK/ConsumptionSaving/ConsMarkovModel.py
+++ b/HARK/ConsumptionSaving/ConsMarkovModel.py
@@ -723,6 +723,7 @@ init_indshk_markov = {
     "pLvlInitMean": 0.0,  # Mean of log initial permanent income
     "pLvlInitStd": 0.0,  # Standard deviation of log initial permanent income
     "PermGroFacAgg": 1.0,  # Aggregate permanent income growth factor
+    "MrkvPrbsInit": [1.0, 0.0],  # Initial distribution of discrete state
     # (The portion of PermGroFac attributable to aggregate productivity growth)
     "NewbornTransShk": False,  # Whether Newborns have transitory shock
     # ADDITIONAL OPTIONAL PARAMETERS
@@ -962,7 +963,6 @@ class MarkovConsumerType(IndShockConsumerType):
             dont_change[:] = True
 
         # Determine which agents are in which states right now
-        J = self.MrkvArray[0].shape[0]
         MrkvPrev = self.shocks["Mrkv"]
         MrkvNow = np.zeros(self.AgentCount, dtype=int)
 
@@ -1083,6 +1083,10 @@ class MarkovConsumerType(IndShockConsumerType):
                 )
         self.controls["cNrm"] = cNrmNow
         self.MPCnow = MPCnow
+
+    def get_poststates(self):
+        super().get_poststates()
+        self.state_now["Mrkv"] = self.shocks["Mrkv"].copy()
 
     def calc_bounding_values(self):
         """

--- a/HARK/ConsumptionSaving/ConsMarkovModel.py
+++ b/HARK/ConsumptionSaving/ConsMarkovModel.py
@@ -723,7 +723,7 @@ init_indshk_markov = {
     "pLvlInitMean": 0.0,  # Mean of log initial permanent income
     "pLvlInitStd": 0.0,  # Standard deviation of log initial permanent income
     "PermGroFacAgg": 1.0,  # Aggregate permanent income growth factor
-    "MrkvPrbsInit": [1.0, 0.0],  # Initial distribution of discrete state
+    "MrkvPrbsInit": np.array([1.0, 0.0]),  # Initial distribution of discrete state
     # (The portion of PermGroFac attributable to aggregate productivity growth)
     "NewbornTransShk": False,  # Whether Newborns have transitory shock
     # ADDITIONAL OPTIONAL PARAMETERS

--- a/HARK/ConsumptionSaving/ConsPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsPortfolioModel.py
@@ -1286,7 +1286,7 @@ class PortfolioConsumerType(RiskyAssetConsumerType):
         """
         IndShockConsumerType.sim_birth(self, which_agents)
 
-        self.controls["Share"][which_agents] = 0
+        self.controls["Share"][which_agents] = 0.0
         # here a shock is being used as a 'post state'
         self.shocks["Adjust"][which_agents] = False
 
@@ -1317,14 +1317,14 @@ class PortfolioConsumerType(RiskyAssetConsumerType):
                 self.state_now["mNrm"][those]
             )
 
-            # Get Controls for agents who *can't* adjust their portfolio share
+            # Get controls for agents who *can't* adjust their portfolio share
             those = np.logical_and(these, np.logical_not(self.shocks["Adjust"]))
             cNrmNow[those] = self.solution[t].cFuncFxd(
-                self.state_now["mNrm"][those], ShareNow[those]
+                self.state_now["mNrm"][those], self.controls["Share"][those]
             )
             ShareNow[those] = self.solution[t].ShareFuncFxd(
-                self.state_now["mNrm"][those], ShareNow[those]
-            )
+                self.state_now["mNrm"][those], self.controls["Share"][those]
+            )  # this just returns same share as before
 
         # Store controls as attributes of self
         self.controls["cNrm"] = cNrmNow

--- a/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
+++ b/HARK/ConsumptionSaving/ConsRiskyAssetModel.py
@@ -487,8 +487,10 @@ class IndShockRiskyAssetConsumerType(IndShockConsumerType):
 
         RfreeNow = super().get_Rfree()
         RiskyNow = self.shocks["Risky"]
-        # ShareNow = self.controls["Share"]
-        ShareNow = np.ones_like(RiskyNow)  # Only asset is risky asset
+        if self.PortfolioBool:
+            ShareNow = self.controls["Share"]
+        else:
+            ShareNow = np.ones_like(RiskyNow)  # Only asset is risky asset
 
         Rport = ShareNow * RiskyNow + (1.0 - ShareNow) * RfreeNow
         self.Rport = Rport


### PR DESCRIPTION
In building the new simulator system, I caught several mistakes in the current system:

- MrkvPrbsInit was missing from default dictionary
- unused definition of J in Markov sim code
- Mrkv wasn't properly accessible in history
- controls were broken when AdjustPrb < 1.0
- Rport was being set as if Share=1 no matter what

This PR fixes those issues.
