### PR TITLE
Support PyPI Trusted Publisher for making releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Build Wheel and Release
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+jobs:
+  build-and-inspect-package:
+    name: Build & inspect package.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  publish:
+    name: Publish release to PyPI
+    if: github.repository_owner == 'econ-ark' && github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+      - name: Generate artifact attestation for sdist and wheel
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fixes https://github.com/econ-ark/HARK/issues/708

Keeping it in draft mode for now as we still need to turn on trusted publisher on pypi side https://docs.pypi.org/trusted-publishers/adding-a-publisher. I can do that if folks think we should go ahead with this :)
