### PR TITLE
Fix Monte Carlo distribution assertion

### DIFF
--- a/HARK/distributions/utils.py
+++ b/HARK/distributions/utils.py
@@ -176,7 +176,7 @@ def make_markov_approx_to_normal_by_monte_carlo(x_grid, mu, sigma, N_draws=10000
     assert (
         (np.all(p_vec >= 0.0))
         and (np.all(p_vec <= 1.0))
-        and (np.isclose(np.sum(p_vec)), 1.0)
+        and (np.isclose(np.sum(p_vec), 1.0))
     )
     return p_vec
 


### PR DESCRIPTION
## Summary
- correct typo in `make_markov_approx_to_normal_by_monte_carlo`

## Testing
- `python -m compileall -q HARK/distributions/utils.py`
- `pytest -k utils -q` *(fails: command not found)*