### PR TITLE
Fix typo in core error message

### DIFF
--- a/HARK/core.py
+++ b/HARK/core.py
@@ -1488,7 +1488,7 @@ class AgentType(Model):
             raise Exception(
                 "This agent type instance must have the attribute T_sim set to a positive integer."
                 + "Set T_sim to match the largest dataset you might simulate, and run this agent's"
-                + "initalizeSim() method before running simulate() again."
+                + "initialize_sim() method before running simulate() again."
             )
 
         if sim_periods is not None and self.T_sim < sim_periods:


### PR DESCRIPTION
## Summary
- reference `initialize_sim()` in error string

## Testing
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=61.2)*