### PR TITLE
Improve numpy usage

### DIFF
--- a/HARK/core.py
+++ b/HARK/core.py
@@ -1227,7 +1227,7 @@ class AgentType(Model):
             self.shock_history["who_dies"][t, :] = self.who_dies
 
             # Initial conditions of newborns
-            if np.sum(self.who_dies) > 0:
+            if self.who_dies.any():
                 for var_name in self.state_vars:
                     # Check whether the state is idiosyncratic or an aggregate
                     idio = (
@@ -1277,7 +1277,7 @@ class AgentType(Model):
         if self.read_shocks:
             who_dies = self.shock_history["who_dies"][self.t_sim, :]
             # Instead of simulating births, assign the saved newborn initial conditions
-            if np.sum(who_dies) > 0:
+            if who_dies.any():
                 for var_name in self.state_now:
                     if var_name in self.newborn_init_history.keys():
                         # Copy only array-like idiosyncratic states. Aggregates should

--- a/HARK/utilities.py
+++ b/HARK/utilities.py
@@ -464,11 +464,12 @@ def kernel_regression(x, y, bot=None, top=None, N=500, h=None):
 
     # Construct a local linear approximation
     x_vec = np.linspace(bot, top, num=N)
-    y_vec = np.zeros_like(x_vec) + np.nan
-    for j in range(N):
-        x_here = x_vec[j]
-        weights = epanechnikov_kernel(x, x_here, h)
-        y_vec[j] = np.dot(weights, y) / np.sum(weights)
+    # Evaluate the kernel for all evaluation points at once
+    weights = epanechnikov_kernel(x[:, None], x_vec[None, :], h)
+    weight_sums = np.sum(weights, axis=0)
+    # Avoid division by zero when weights are extremely small
+    weight_sums[weight_sums == 0] = np.nan
+    y_vec = np.dot(weights.T, y) / weight_sums
     regression = interp1d(x_vec, y_vec, bounds_error=False, assume_sorted=True)
     return regression
 
@@ -492,9 +493,8 @@ def epanechnikov_kernel(x, ref_x, h=1.0):
         Kernel values at each value of x
     """
     u = (x - ref_x) / h  # Normalize distance by bandwidth
-    these = np.abs(u) <= 1.0  # Kernel = 0 outside [-1,1]
-    out = np.zeros_like(x)  # Initialize kernel output
-    out[these] = 0.75 * (1.0 - u[these] ** 2.0)  # Evaluate kernel
+    out = 0.75 * (1.0 - u**2)
+    out[np.abs(u) > 1.0] = 0.0  # Kernel = 0 outside [-1,1]
     return out
 
 
@@ -518,12 +518,9 @@ def make_polynomial_params(coeffs, T, offset=0.0, step=1.0):
     param_vals : np.array
         T-length array of parameter values calculated using the polynomial coefficients.
     """
-    N = len(coeffs)
     X = offset + step * np.arange(T)
-    param_vals = np.zeros_like(X)
-    for n in range(N):
-        param_vals += coeffs[n] * X**n
-    return param_vals
+    # np.polyval expects highest power first
+    return np.polyval(coeffs[::-1], X)
 
 
 @numba.njit


### PR DESCRIPTION
## Summary
- vectorize kernel regression computations
- streamline epanechnikov kernel
- use numpy indexing to get interest rates
- evaluate polynomials with `np.polyval`
- eliminate loops in idiosyncratic-shock consumer functions
- use boolean arrays directly in `core.AgentType`

## Testing
- `ruff check --fix HARK/core.py HARK/ConsumptionSaving/ConsIndShockModel.py`
- `pytest -n auto` *(fails: KeyboardInterrupt)*