### PR TITLE
Clean distance metric warnings, stop simulate() from returning history

### DIFF
--- a/HARK/core.py
+++ b/HARK/core.py
@@ -1528,8 +1528,6 @@ class AgentType(Model):
                             )
                 self.t_sim += 1
 
-            return self.history
-
     def clear_history(self):
         """
         Clears the histories of the attributes named in self.track_vars.

--- a/HARK/metric.py
+++ b/HARK/metric.py
@@ -5,61 +5,47 @@ import numpy as np
 
 def distance_lists(list_a, list_b):
     """
-    If both inputs are lists, then the distance between
-    them is the maximum distance between corresponding
-    elements in the lists.  If they differ in length,
-    the distance is the difference in lengths.
+    If both inputs are lists, then the distance between them is the maximum
+    distance between corresponding elements in the lists.  If they differ in
+    length, the distance is the difference in lengths.
     """
     len_a = len(list_a)
     len_b = len(list_b)
     if len_a == len_b:
         return np.max([distance_metric(list_a[n], list_b[n]) for n in range(len_a)])
-    warn("Objects of different lengths. Returning difference in lengths.")
     return np.abs(len_a - len_b)
 
 
 def distance_dicts(dict_a, dict_b):
     """
-    If both inputs are dictionaries, call distance on the list of its elements
-    If keys don't match, print a warning.
-    If they have different lengths, log a warning and return the
-    difference in lengths.
+    If both inputs are dictionaries, call distance on the list of its elements.
+    If they do not have the same keys, return 1000 and raise a warning. Nothing
+    in HARK should ever hit that warning.
     """
-    len_a = len(dict_a)
-    len_b = len(dict_b)
-
-    if len_a == len_b:
-        if set(dict_a.keys()) != set(dict_b.keys()):
-            warn("Dictionaries with keys that do not match are being compared.")
-            return 1000.0
-        return np.max(
-            [distance_metric(dict_a[key], dict_b[key]) for key in dict_a.keys()]
-        )
-    warn("Objects of different lengths. Returning difference in lengths.")
-    return np.abs(len_a - len_b)
+    if set(dict_a.keys()) != set(dict_b.keys()):
+        warn("Dictionaries with keys that do not match are being compared.")
+        return 1000.0
+    return np.max([distance_metric(dict_a[key], dict_b[key]) for key in dict_a.keys()])
 
 
 def distance_arrays(arr_a, arr_b):
     """
     If both inputs are array-like, return the maximum absolute difference b/w
-    corresponding elements (if same shape); return largest difference in dimensions
-    if shapes do not align.
-    Flatten arrays so they have the same dimensions
+    corresponding elements (if same shape); return difference in size if shapes
+    do not align.
     """
-
     if arr_a.shape == arr_b.shape:
         return np.max(np.abs(arr_a - arr_b))
-    warn("Arrays of different shapes. Returning differences in size.")
     return np.abs(arr_a.size - arr_b.size)
 
 
 def distance_class(cls_a, cls_b):
     """
-    If none of the above cases, but the objects are of the same class,
-    call the distance method of one on the other
+    If none of the above cases, but the objects are of the same class, call the
+    distance method of one on the other.
     """
     if isinstance(cls_a, type(lambda: None)):
-        warn("Cannot compare functions. Returning large distance.")
+        warn("Cannot compare lambda functions. Returning large distance.")
         return 1000.0
     return cls_a.distance(cls_b)
 


### PR DESCRIPTION
As long as we're doing small pull requests, this PR fixes two things that have been irking me for a while.

1) Someone added warnings to the distance metric sub-functions when they encounter "unusual" cases. Some of those cases really are strange, but others are part of normal HARK solvers. Particularly, when lists or arrays aren't the same length / shape, there's no need to raise a warning. This happens in `PerfForesight` because the terminal criteria is reached (in most cases) when some maximum number of gridpoints is reached (after that many periods of solving). Before that point, each successive solution has 1 more gridpoint than the last one, and the distance metric reports that there is *no way* that these are the same thing.

2) Someone made `simulate()` return the history dictionary, which led to some utterly massive notebook output that we don't want (when `ThisType.simulate()` is in the last line of a cell). I deleted that line.