### PR TITLE
Remove duplicated pfnm test

### DIFF
--- a/HARK/models/test_models.py
+++ b/HARK/models/test_models.py
@@ -70,27 +70,6 @@ class test_pfnm(unittest.TestCase):
         self.mcs.simulate()
 
 
-class test_pfnm(unittest.TestCase):
-    def setUp(self):
-        self.mcs = AgentTypeMonteCarloSimulator(  ### Use fm, blockified
-            pfnm.calibration,
-            pfnm.block,
-            {"c_nrm": lambda m_nrm: PFexample.solution[0].cFunc(m_nrm)},
-            {  # initial states
-                "a_nrm": Lognormal(-6, 0),
-                #'live' : 1,
-                "p": 1.0,
-            },
-            agent_count=3,
-            T_sim=120,
-        )
-
-    def test_simulate(self):
-        ## smoke test
-        self.mcs.initialize_sim()
-        self.mcs.simulate()
-
-
 class test_consumer_models(unittest.TestCase):
     def setUp(self):
         self.cs = AgentTypeMonteCarloSimulator(  ### Use fm, blockified


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.

This small PR removes the duplicated `test_pfnm` in `HARK/models/test_models.py` which contains the same logic.