### PR TITLE
AdjustDstn was missing from WealthPortfolioModel

### DIFF
--- a/HARK/ConsumptionSaving/ConsWealthPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsWealthPortfolioModel.py
@@ -27,6 +27,7 @@ from HARK.Calibration.Income.IncomeProcesses import (
 )
 from HARK.ConsumptionSaving.ConsRiskyAssetModel import (
     make_simple_ShareGrid,
+    make_AdjustDstn,
 )
 from HARK.rewards import UtilityFuncCRRA
 from HARK.utilities import NullFunc, make_assets_grid
@@ -521,6 +522,7 @@ WealthPortfolioConsumerType_constructors_default = {
     "ShareLimit": calc_ShareLimit_for_CRRA,
     "ShareGrid": make_simple_ShareGrid,
     "ChiFunc": make_ChiFromOmega_function,
+    "AdjustDstn": make_AdjustDstn,
     "solution_terminal": make_portfolio_solution_terminal,
 }
 


### PR DESCRIPTION
Two line fix to make LC-primetime project work with 0.16.0 / 0.16.1.
