### PR TITLE
Turn off use_infimum

### DIFF
--- a/HARK/ConsumptionSaving/ConsIndShockModel.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModel.py
@@ -460,7 +460,7 @@ def solve_one_period_ConsPF(
     return solution_now
 
 
-def calc_worst_inc_prob(inc_shk_dstn, use_infimum=True):
+def calc_worst_inc_prob(inc_shk_dstn, use_infimum=False):
     """Calculate the probability of the worst income shock.
 
     Args:
@@ -478,7 +478,7 @@ def calc_worst_inc_prob(inc_shk_dstn, use_infimum=True):
 
 
 def calc_boro_const_nat(
-    m_nrm_min_next, inc_shk_dstn, rfree, perm_gro_fac, use_infimum=True
+    m_nrm_min_next, inc_shk_dstn, rfree, perm_gro_fac, use_infimum=False
 ):
     """Calculate the natural borrowing constraint.
 

--- a/tests/ConsumptionSaving/test_ConsNewKeynesianModel.py
+++ b/tests/ConsumptionSaving/test_ConsNewKeynesianModel.py
@@ -39,7 +39,7 @@ class test_Transition_Matrix_Methods(unittest.TestCase):
         AggC = np.dot(gridc.flatten(), vecDstn)  # Aggregate Consumption
         AggA = np.dot(grida.flatten(), vecDstn)  # Aggregate Assets
 
-        self.assertAlmostEqual(AggA[0], 0.82960, places=4)
+        self.assertAlmostEqual(AggA[0], 0.82983, places=4)
         self.assertAlmostEqual(AggC[0], 1.00780, places=4)
 
 
@@ -52,6 +52,6 @@ class test_Jacobian_methods(unittest.TestCase):
         Agent.compute_steady_state()
         CJAC_Perm, AJAC_Perm = Agent.calc_jacobian("PermShkStd", 50)
 
-        self.assertAlmostEqual(CJAC_Perm.T[30][29], -0.10508, places=HARK_PRECISION)
+        self.assertAlmostEqual(CJAC_Perm.T[30][29], -0.10503, places=HARK_PRECISION)
         self.assertAlmostEqual(CJAC_Perm.T[30][30], 0.10316, places=HARK_PRECISION)
         self.assertAlmostEqual(CJAC_Perm.T[30][31], 0.09059, places=HARK_PRECISION)

--- a/tests/ConsumptionSaving/test_IndShockConsumerType.py
+++ b/tests/ConsumptionSaving/test_IndShockConsumerType.py
@@ -50,17 +50,17 @@ class testIndShockConsumerType(unittest.TestCase):
 
         self.assertAlmostEqual(
             LifecycleExample.solution[0].cFunc(1).tolist(),
-            0.75074,
+            0.75062,
             places=HARK_PRECISION,
         )
         self.assertAlmostEqual(
             LifecycleExample.solution[1].cFunc(1).tolist(),
-            0.75876,
+            0.75863,
             places=HARK_PRECISION,
         )
         self.assertAlmostEqual(
             LifecycleExample.solution[2].cFunc(1).tolist(),
-            0.76824,
+            0.76812,
             places=HARK_PRECISION,
         )
 
@@ -227,7 +227,7 @@ class testIndShockConsumerTypeExample(unittest.TestCase):
         IndShockExample.solve()
 
         self.assertAlmostEqual(
-            IndShockExample.solution[0].mNrmStE, 1.54765, places=HARK_PRECISION
+            IndShockExample.solution[0].mNrmStE, 1.54882, places=HARK_PRECISION
         )
         # self.assertAlmostEqual(
         #    IndShockExample.solution[0].cFunc.functions[0].x_list[0],
@@ -311,7 +311,7 @@ class testIndShockConsumerTypeLifecycle(unittest.TestCase):
 
         self.assertAlmostEqual(
             LifecycleExample.solution[5].cFunc(3).tolist(),
-            2.13004,
+            2.12998,
             places=HARK_PRECISION,
         )
 
@@ -385,7 +385,7 @@ class testIndShockConsumerTypeCyclical(unittest.TestCase):
 
         self.assertAlmostEqual(
             CyclicalExample.solution[3].cFunc(3).tolist(),
-            1.59597,
+            1.59584,
             places=HARK_PRECISION,
         )
 
@@ -393,7 +393,7 @@ class testIndShockConsumerTypeCyclical(unittest.TestCase):
         CyclicalExample.simulate()
 
         self.assertAlmostEqual(
-            CyclicalExample.state_now["aLvl"][1], 3.8924, places=HARK_PRECISION
+            CyclicalExample.state_now["aLvl"][1], 3.90015, places=HARK_PRECISION
         )
 
 

--- a/tests/ConsumptionSaving/test_modelcomparisons.py
+++ b/tests/ConsumptionSaving/test_modelcomparisons.py
@@ -47,7 +47,7 @@ class Compare_PerfectForesight_and_Infinite(unittest.TestCase):
         test_dictionary["UnempPrb"] = 0.0
         test_dictionary["T_cycle"] = 1
         test_dictionary["T_retire"] = 0
-        test_dictionary["BoroCnstArt"] = 0.0
+        test_dictionary["BoroCnstArt"] = None
 
         InfiniteType = IndShockConsumerType(**test_dictionary)
         InfiniteType.cycles = 0


### PR DESCRIPTION
This feature wasn't ready for primetime and is causing bad numeric behavior with vFuncBool. Test targets have been reverted.