### PR TITLE
Add two more options to LinearInterp

### DIFF
--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -53,6 +53,33 @@ class testsLinearInterp(unittest.TestCase):
         X = np.linspace(0.0, 4.0, 101)
         self.assertTrue(np.all(np.isclose(f(X), g(X))))
 
+    def testIndexer(self):
+        bot = 1.0
+        top = 10.0
+        N = 30
+        order = 2.5
+        grid = (top - bot) * np.linspace(0.0, 1.0, N) ** order + bot
+
+        def my_indexer(x):
+            below = x < bot
+            above = x > top
+            these = np.logical_not(np.logical_or(below, above))
+            i = np.zeros_like(x, dtype=int)
+            i[these] = np.ceil(
+                (N - 1) * ((x[these] - bot) / (top - bot)) ** (1.0 / order)
+            )
+            i[below] = 1
+            i[above] = N - 1
+            return i
+
+        f = np.log
+        data = f(grid)
+        g = LinearInterp(grid, data)  # default indexing with searchsorted
+        h = LinearInterp(grid, data, indexer=my_indexer)  # custom indexing
+
+        X = np.linspace(2, 11, 101)
+        self.assertTrue(np.all(np.isclose(g(X), h(X))))
+
 
 class testsCubicInterp(unittest.TestCase):
     """tests for CubicInterp, currently tests for uneven length of


### PR DESCRIPTION
This PR adds two optional arguments to the initializer for `HARK.interpolation.LinearInterp`:

- `pre_compute` is a boolean flag (default False) that tells the initializer to precompute the slope and intercept of each segment, storing them as attributes of self. Those slopes and intercepts are then used during evaluation, which is marginally faster than the default "linear weighting" method. This option uses additional memory, but moves some computation from evaluation time to initialization time, potentially a net speedup.
- `indexer` is an optional function argument that supplants the default segment indexing using `np.searchsorted`. The user is responsible for ensuring that their indexer functions identically to the default/intended behavior. This is useful for large grids whose spacing is "invertible"-- there is a (small) function that quickly yields the segment index for any query point-- because it avoids the O(log N) searchsorted operation.

- [x] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [x] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.
