### PR TITLE
Uncomment test that breaks automated tester

### DIFF
--- a/.github/workflows/hark.yml
+++ b/.github/workflows/hark.yml
@@ -35,4 +35,4 @@ jobs:
           pip install ".[dev]"
       - name: Test with pytest
         run: |
-          pytest
+          pytest -n auto

--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,4 @@ spyproject
 
 # 20240608: CDC added *private* to avoid accidentally uploading private material
 *private*
+uv.lock

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -225,7 +225,7 @@ class testMarkovEvents(unittest.TestCase):
             "N": 201,
         }
         Mrkv_grid = {"N": 2}
-        self.grid_specs = {"kNrm": kNrm_grid, "cNrm": cNrm_grid, "z": Mrkv_grid}
+        self.grid_specs = {"kNrm": kNrm_grid, "cNrm": cNrm_grid, "zPrev": Mrkv_grid}
 
     def test_simulation(self):
         self.agent.track_vars = ["aNrm", "cNrm", "Mrkv"]


### PR DESCRIPTION
This test runs fine locally, but it crashes on the remote. I am making this commit/PR so that hopefully the problem can be diagnosed at some point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables the Markov SSJ unit test and updates grid spec key from `z` to `zPrev`; adds `uv.lock` to `.gitignore`.
> 
> - **Tests**:
>   - **Markov events**:
>     - Update `grid_specs` to use `"zPrev"` instead of `"z"` in `tests/test_simulate.py`.
>     - Uncomment and execute `make_basic_SSJ("Mrkv_p11", ["cNrm", "aNrm"], ...)`.
> - **Gitignore**:
>   - Add `uv.lock` to ignored files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0e98c51d5a74c3b05ba787d9b1c9b907b1e8e93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->