### PR TITLE
Add tests for Parameters class

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -356,6 +356,7 @@ class TestParameters:
     def test_add_to_time_vary_nonexistent(self, sample_params):
         """Test adding non-existent parameter to time-varying set issues warning."""
         import warnings
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             sample_params.add_to_time_vary("nonexistent")
@@ -375,6 +376,7 @@ class TestParameters:
     def test_add_to_time_inv_nonexistent(self, sample_params):
         """Test adding non-existent parameter to time-invariant set issues warning."""
         import warnings
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             sample_params.add_to_time_inv("nonexistent")
@@ -432,10 +434,14 @@ class TestParameters:
 
     def test_update_invalid_type(self, sample_params):
         """Test updating with invalid type raises TypeError."""
-        with pytest.raises(TypeError, match="must be a Parameters object or a dictionary"):
+        with pytest.raises(
+            TypeError, match="must be a Parameters object or a dictionary"
+        ):
             sample_params.update([1, 2, 3])
 
-        with pytest.raises(TypeError, match="must be a Parameters object or a dictionary"):
+        with pytest.raises(
+            TypeError, match="must be a Parameters object or a dictionary"
+        ):
             sample_params.update("invalid")
 
     def test_setitem_numpy_array(self):
@@ -456,8 +462,10 @@ class TestParameters:
     def test_setitem_callable(self):
         """Test setting parameters with callable values."""
         params = Parameters(T_cycle=3)
+
         def test_func():
             return 42
+
         params["func_param"] = test_func
         assert params["func_param"] == test_func
         assert "func_param" in params._invariant_params
@@ -502,16 +510,13 @@ class TestParameters:
         params = Parameters(a=[1, 2, 3, 4])
         assert params._length == 4
         # Note: T_cycle parameter is set during init, _length is inferred from lists
-        assert params["T_cycle"] == 1  # Initial value since T_cycle not explicitly provided
+        assert (
+            params["T_cycle"] == 1
+        )  # Initial value since T_cycle not explicitly provided
 
     def test_getitem_age_with_numpy_array(self):
         """Test accessing by age when parameters include numpy arrays."""
-        params = Parameters(
-            a=np.array([1, 2, 3]),
-            b=[4, 5, 6],
-            c=7,
-            T_cycle=3
-        )
+        params = Parameters(a=np.array([1, 2, 3]), b=[4, 5, 6], c=7, T_cycle=3)
         age_params = params[1]
         # Numpy arrays are time-invariant, so the entire array is returned
         assert np.array_equal(age_params["a"], np.array([1, 2, 3]))
@@ -520,11 +525,7 @@ class TestParameters:
 
     def test_getitem_age_with_tuple(self):
         """Test accessing by age when parameters are tuples."""
-        params = Parameters(
-            a=(1, 2, 3),
-            b=4,
-            T_cycle=3
-        )
+        params = Parameters(a=(1, 2, 3), b=4, T_cycle=3)
         age_params = params[2]
         assert age_params["a"] == 3
         assert age_params["b"] == 4


### PR DESCRIPTION
This commit adds 40 new test cases for the Parameters class to improve test coverage:

- Iteration methods: __iter__, __len__, keys(), values(), items()
- String representations: __repr__, __str__
- Attribute-style access: __getattr__, __setattr__, with error cases
- Membership testing: __contains__ operator
- Deep copy functionality: copy()
- Time-varying management: add_to_time_vary(), add_to_time_inv(), del_from_time_vary(), del_from_time_inv()
- Conversion methods: to_namedtuple()
- Edge cases for __getitem__: out of bounds, non-existent keys, wrong types
- Update functionality: from dictionaries and error cases
- Various parameter types: numpy arrays, booleans, callables, None, Distribution objects, tuples
- Initialization edge cases: no T_cycle, inferred T_cycle, empty initialization
- Single-element list handling
- Age-based access with different parameter types

All 50 tests pass successfully.

Please ensure your pull request adheres to the following guidelines:

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Tests for new functionality/models or Tests to reproduce the bug-fix in code.
- [ ] Updated documentation of features that add new functionality.
- [ ] Update CHANGELOG.md with major/minor changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive tests for Parameters covering iteration/accessors, time-varying management, updates, type handling, and initialization/edge cases.
> 
> - **Tests**:
>   - **`tests/test_core.py`**: Add extensive `Parameters` coverage:
>     - Iteration/accessors: `__iter__`, `__len__`, `keys`, `values`, `items`, `__repr__`, `__str__`, attribute get/set, `__contains__`, `copy`, `to_namedtuple`.
>     - Time-variance management: `add_to_time_vary`, `add_to_time_inv`, `del_from_time_vary`, `del_from_time_inv`, with nonexistent param warnings.
>     - Indexing/lookup edge cases: out-of-bounds age, nonexistent keys, wrong index types.
>     - Updates: `update` from `Parameters` and `dict`; invalid-type errors.
>     - Type handling: numpy arrays, booleans, callables, `None`, `Distribution`, tuples, single-element list unwrapping; unsupported type error.
>     - Initialization scenarios: default/no `T_cycle`, inferred length from lists, empty initialization, age-based access with arrays/tuples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 213106fdb03e8a06a80166eadc69bce726fa36e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->