### PR TITLE
Fix typo in BasicHealth simulation

### DIFF
--- a/HARK/ConsumptionSaving/ConsHealthModel.py
+++ b/HARK/ConsumptionSaving/ConsHealthModel.py
@@ -602,7 +602,7 @@ class BasicHealthConsumerType(AgentType):
         """
         # Calculate agent-specific death probability
         phi = np.array(self.DieProbMax)[self.t_cycle]
-        DieProb = phi / (1.0 + self.state_now["hLvl"])
+        DieProb = phi / (1.0 + self.state_now["HLvl"])
 
         # Draw mortality shocks and mark who dies
         N = self.AgentCount


### PR DESCRIPTION
This fixes #1636 ; it's a one character capitalization typo.