### PR TITLE
Add .venv*/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Virtual Environments
 venv/
+.venv*/
 econ-ark/
 
 # C extensions


### PR DESCRIPTION
Adds `.venv*/` pattern to `.gitignore` to prevent virtual environments with the `.venv` naming convention from being accidentally staged or committed.

The existing `venv/` entry doesn't cover the common `.venv` pattern (with leading dot).