### PR TITLE
Add .specstory/ and .cursor* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,5 @@ spyproject
 # 20240608: CDC added *private* to avoid accidentally uploading private material
 *private*
 uv.lock
+.cursor*
+.specstory/


### PR DESCRIPTION
## Summary

Adds gitignore entries for AI assistant tooling files:

- `.specstory/` - Contains AI conversation history (used by some AI assistants to maintain context)
- `.cursor*` - Cursor IDE configuration and indexing files

These files are developer-specific and should not be committed to the repository.