### PR TITLE
Unpack and simulator handle dictionary solutions

### DIFF
--- a/HARK/core.py
+++ b/HARK/core.py
@@ -1168,7 +1168,7 @@ class AgentType(Model):
             if param in self.time_inv:
                 self.time_inv.remove(param)
 
-    def unpack(self, parameter):
+    def unpack(self, name):
         """
         Unpacks an attribute from a solution object for easier access.
         After the model has been solved, its components (like consumption function)
@@ -1178,7 +1178,7 @@ class AgentType(Model):
 
         Parameters
         ----------
-        parameter: str
+        name: str
             Name of the attribute to unpack from the solution
 
         Returns
@@ -1186,12 +1186,11 @@ class AgentType(Model):
         none
         """
         # Use list comprehension for better performance instead of loop with append
-        setattr(
-            self,
-            parameter,
-            [solution_t.__dict__[parameter] for solution_t in self.solution],
-        )
-        self.add_to_time_vary(parameter)
+        if type(self.solution[0]) is dict:
+            setattr(self, name, [soln_t[name] for soln_t in self.solution])
+        else:
+            setattr(self, name, [soln_t.__dict__[name] for soln_t in self.solution])
+        self.add_to_time_vary(name)
 
     def solve(
         self,

--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -1773,7 +1773,10 @@ def make_simulator_from_agent(agent, stop_dead=True, replace_dead=True, common=N
         new_param_dict = deepcopy(time_inv_dict)
         for name in content:
             if name in solution:
-                new_param_dict[name] = getattr(agent.solution[t], name)
+                if type(agent.solution[t]) is dict:
+                    new_param_dict[name] = agent.solution[t][name]
+                else:
+                    new_param_dict[name] = getattr(agent.solution[t], name)
             elif name in time_vary:
                 s = (t_cycle - 1) if name in offset else t_cycle
                 try:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,8 @@ none yet
 - multi_thread_commands[_fake] no longer requires empty parentheses to be included with each method name (now optional). [#1692](https://github.com/econ-ark/HARK/pull/1692)
 - Added __repr__ method for DiscreteDistribution (and subclasses) to display basic information about itself.
 - All AgentTypes now have sensible defaults for track_vars if none is provided. [#1693](https://github.com/econ-ark/HARK/pull/1693)
+- `AgentType.unpack` and the new simulation structure appropriately handle solutions represented as dictionaries. [#1709](https://github.com/econ-ark/HARK/pull/1709)
+
 
 ### 0.17.0
 

--- a/tests/ConsumptionSaving/test_ConsMedModel.py
+++ b/tests/ConsumptionSaving/test_ConsMedModel.py
@@ -8,8 +8,7 @@ from HARK.ConsumptionSaving.ConsMedModel import (
 
 class testMedShockConsumerType(unittest.TestCase):
     def setUp(self):
-        self.agent = MedShockConsumerType()
-        self.agent.vFuncBool = True
+        self.agent = MedShockConsumerType(vFuncBool=True)
         self.agent.solve()
 
     def test_solution(self):
@@ -24,6 +23,10 @@ class testMedShockConsumerType(unittest.TestCase):
         self.assertAlmostEqual(
             MedFunc(mLvl, pLvl, Shk).tolist(), 2.40487, places=HARK_PRECISION
         )
+
+    def test_unpack(self):
+        # This test is relevant because solution representation is a dictionary
+        self.agent.unpack("vFunc")
 
     def test_value(self):
         vFunc = self.agent.solution[0].vFunc


### PR DESCRIPTION
`AgentType.unpack` and the new simulation structure can now handle `solution[t]` being dictionaries with keys rather than objects with attributes.

The test added for ConsMedModel isn't relevant until #1706 is merged. One line in the simulator code won't be reached by tests at all.

This commit addresses issue #1707