### PR TITLE
Add method to export simulated data to `pandas.DataFrame`

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1410,18 +1410,18 @@ class test_export_to_df(unittest.TestCase):
 
         df = self.agent.export_to_df(var=["aNrm", "cNrm"], t=10, sym=True)
         self.assertEqual(df.shape[0], self.agent.AgentCount)
-        self.assertEqual(df.shape[1], 2)  # 4 tracked variables
+        self.assertEqual(df.shape[1], 2)  # 2 tracked variables
         self.assertFalse(np.any(np.isnan(df.values)))  # no missing data
 
     def test_one_t_by_age(self):
         df = self.agent.export_to_df(t=10, by_age=True, sym=True)
-        self.assertTrue(df.shape[0] > self.agent.AgentCount)
+        self.assertGreater(df.shape[0], self.agent.AgentCount)
         self.assertEqual(df.shape[1], 4)  # 4 tracked variables
         self.assertFalse(np.any(np.isnan(df.values)))  # no missing data
 
         df = self.agent.export_to_df(var=["aNrm", "cNrm"], by_age=True, t=10, sym=True)
-        self.assertTrue(df.shape[0] > self.agent.AgentCount)
-        self.assertEqual(df.shape[1], 2)  # 4 tracked variables
+        self.assertGreater(df.shape[0], self.agent.AgentCount)
+        self.assertEqual(df.shape[1], 2)  # 2 tracked variables
         self.assertFalse(np.any(np.isnan(df.values)))  # no missing data
 
     def test_invalid(self):
@@ -1429,6 +1429,9 @@ class test_export_to_df(unittest.TestCase):
         self.assertRaises(KeyError, self.agent.export_to_df, var="boop", sym=True)
         self.assertRaises(
             KeyError, self.agent.export_to_df, t=5, var=["boop"], sym=True
+        )
+        self.assertRaises(
+            ValueError, self.agent.export_to_df, var="aNrm", t=10, sym=True
         )
 
         self.agent.track_vars = ["mNrm", "aNrm", "cNrm"]


### PR DESCRIPTION
This PR is meant to address issue #837 . It adds the method `AgentType.export_to_df` as a convenient interface to build a pandas dataframe object from simulated data in `history` (or `hystory`).

As of this moment, no code has been written, only the docstring. I'm trying to make it simple and mostly intuitive, while covering the main use-cases.