### PR TITLE
Add finite difference derivatives to interpolators

### DIFF
--- a/HARK/interpolation.py
+++ b/HARK/interpolation.py
@@ -135,15 +135,24 @@ class HARKinterpolator1D(MetricObject):
 
     def _der(self, x):
         """
-        Interpolated function derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative method using finite difference approximation.
+        Subclasses of HARKinterpolator1D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(x)
+        f1 = self._evaluate(x + eps)
+        dydx = (f1 - f0) / eps
+        return dydx
 
     def _evalAndDer(self, x):
         """
         Interpolated function and derivative evaluator, to be defined in subclasses.
+        Default implementation separately calls the _evaluate and _der methods, which
+        might be inefficient relative to interpolator-specific implementation.
         """
-        raise NotImplementedError()
+        y = self._evaluate(x)
+        dydx = self._der(x)
+        return y, dydx
 
 
 class HARKinterpolator2D(MetricObject):
@@ -238,15 +247,25 @@ class HARKinterpolator2D(MetricObject):
 
     def _derX(self, x, y):
         """
-        Interpolated function x-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to x, using finite difference approximation.
+        Subclasses of HARKinterpolator2D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(x, y)
+        f1 = self._evaluate(x + eps, y)
+        dfdx = (f1 - f0) / eps
+        return dfdx
 
     def _derY(self, x, y):
         """
-        Interpolated function y-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to y, using finite difference approximation.
+        Subclasses of HARKinterpolator2D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(x, y)
+        f1 = self._evaluate(x, y + eps)
+        dfdy = (f1 - f0) / eps
+        return dfdy
 
 
 class HARKinterpolator3D(MetricObject):
@@ -389,21 +408,36 @@ class HARKinterpolator3D(MetricObject):
 
     def _derX(self, x, y, z):
         """
-        Interpolated function x-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to x, using finite difference approximation.
+        Subclasses of HARKinterpolator3D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(x, y, z)
+        f1 = self._evaluate(x + eps, y, z)
+        dfdx = (f1 - f0) / eps
+        return dfdx
 
     def _derY(self, x, y, z):
         """
-        Interpolated function y-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to y, using finite difference approximation.
+        Subclasses of HARKinterpolator3D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(x, y, z)
+        f1 = self._evaluate(x, y + eps, z)
+        dfdy = (f1 - f0) / eps
+        return dfdy
 
     def _derZ(self, x, y, z):
         """
-        Interpolated function y-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to z, using finite difference approximation.
+        Subclasses of HARKinterpolator3D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(x, y, z)
+        f1 = self._evaluate(x, y, z + eps)
+        dfdz = (f1 - f0) / eps
+        return dfdz
 
 
 class HARKinterpolator4D(MetricObject):
@@ -610,27 +644,47 @@ class HARKinterpolator4D(MetricObject):
 
     def _derW(self, w, x, y, z):
         """
-        Interpolated function w-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to w, using finite difference approximation.
+        Subclasses of HARKinterpolator4D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(w, x, y, z)
+        f1 = self._evaluate(w + eps, x, y, z)
+        dfdw = (f1 - f0) / eps
+        return dfdw
 
     def _derX(self, w, x, y, z):
         """
-        Interpolated function w-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to x, using finite difference approximation.
+        Subclasses of HARKinterpolator4D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(w, x, y, z)
+        f1 = self._evaluate(w, x + eps, y, z)
+        dfdx = (f1 - f0) / eps
+        return dfdx
 
     def _derY(self, w, x, y, z):
         """
-        Interpolated function w-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to y, using finite difference approximation.
+        Subclasses of HARKinterpolator4D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(w, x, y, z)
+        f1 = self._evaluate(w, x, y + eps, z)
+        dfdy = (f1 - f0) / eps
+        return dfdy
 
     def _derZ(self, w, x, y, z):
         """
-        Interpolated function w-derivative evaluator, to be defined in subclasses.
+        Default or fallback derivative with respect to z, using finite difference approximation.
+        Subclasses of HARKinterpolator4D should define their own more specific method.
         """
-        raise NotImplementedError()
+        eps = 1e-8
+        f0 = self._evaluate(w, x, y, z)
+        f1 = self._evaluate(w, x, y, z + eps)
+        dfdz = (f1 - f0) / eps
+        return dfdz
 
 
 class IdentityFunction(MetricObject):

--- a/HARK/interpolation.py
+++ b/HARK/interpolation.py
@@ -139,8 +139,8 @@ class HARKinterpolator1D(MetricObject):
         Subclasses of HARKinterpolator1D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(x)
-        f1 = self._evaluate(x + eps)
+        f0 = self.__call__(x)
+        f1 = self.__call__(x + eps)
         dydx = (f1 - f0) / eps
         return dydx
 
@@ -251,8 +251,8 @@ class HARKinterpolator2D(MetricObject):
         Subclasses of HARKinterpolator2D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(x, y)
-        f1 = self._evaluate(x + eps, y)
+        f0 = self.__call__(x, y)
+        f1 = self.__call__(x + eps, y)
         dfdx = (f1 - f0) / eps
         return dfdx
 
@@ -262,8 +262,8 @@ class HARKinterpolator2D(MetricObject):
         Subclasses of HARKinterpolator2D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(x, y)
-        f1 = self._evaluate(x, y + eps)
+        f0 = self.__call__(x, y)
+        f1 = self.__call__(x, y + eps)
         dfdy = (f1 - f0) / eps
         return dfdy
 
@@ -412,8 +412,8 @@ class HARKinterpolator3D(MetricObject):
         Subclasses of HARKinterpolator3D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(x, y, z)
-        f1 = self._evaluate(x + eps, y, z)
+        f0 = self.__call__(x, y, z)
+        f1 = self.__call__(x + eps, y, z)
         dfdx = (f1 - f0) / eps
         return dfdx
 
@@ -423,8 +423,8 @@ class HARKinterpolator3D(MetricObject):
         Subclasses of HARKinterpolator3D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(x, y, z)
-        f1 = self._evaluate(x, y + eps, z)
+        f0 = self.__call__(x, y, z)
+        f1 = self.__call__(x, y + eps, z)
         dfdy = (f1 - f0) / eps
         return dfdy
 
@@ -434,8 +434,8 @@ class HARKinterpolator3D(MetricObject):
         Subclasses of HARKinterpolator3D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(x, y, z)
-        f1 = self._evaluate(x, y, z + eps)
+        f0 = self.__call__(x, y, z)
+        f1 = self.__call__(x, y, z + eps)
         dfdz = (f1 - f0) / eps
         return dfdz
 
@@ -648,8 +648,8 @@ class HARKinterpolator4D(MetricObject):
         Subclasses of HARKinterpolator4D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(w, x, y, z)
-        f1 = self._evaluate(w + eps, x, y, z)
+        f0 = self.__call__(w, x, y, z)
+        f1 = self.__call__(w + eps, x, y, z)
         dfdw = (f1 - f0) / eps
         return dfdw
 
@@ -659,8 +659,8 @@ class HARKinterpolator4D(MetricObject):
         Subclasses of HARKinterpolator4D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(w, x, y, z)
-        f1 = self._evaluate(w, x + eps, y, z)
+        f0 = self.__call__(w, x, y, z)
+        f1 = self.__call__(w, x + eps, y, z)
         dfdx = (f1 - f0) / eps
         return dfdx
 
@@ -670,8 +670,8 @@ class HARKinterpolator4D(MetricObject):
         Subclasses of HARKinterpolator4D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(w, x, y, z)
-        f1 = self._evaluate(w, x, y + eps, z)
+        f0 = self.__call__(w, x, y, z)
+        f1 = self.__call__(w, x, y + eps, z)
         dfdy = (f1 - f0) / eps
         return dfdy
 
@@ -681,8 +681,8 @@ class HARKinterpolator4D(MetricObject):
         Subclasses of HARKinterpolator4D should define their own more specific method.
         """
         eps = 1e-8
-        f0 = self._evaluate(w, x, y, z)
-        f1 = self._evaluate(w, x, y, z + eps)
+        f0 = self.__call__(w, x, y, z)
+        f1 = self.__call__(w, x, y, z + eps)
         dfdz = (f1 - f0) / eps
         return dfdz
 
@@ -2409,7 +2409,6 @@ class LowerEnvelope2D(HARKinterpolator2D):
         for j in range(self.funcCount):
             temp[:, j] = self.functions[j](x, y)
         i = self.argcompare(temp, axis=1)
-        y = temp[np.arange(m), i]
         dfdy = np.zeros_like(x)
         for j in np.unique(i):
             c = i == j
@@ -2485,7 +2484,6 @@ class LowerEnvelope3D(HARKinterpolator3D):
         for j in range(self.funcCount):
             temp[:, j] = self.functions[j](x, y, z)
         i = self.argcompare(temp, axis=1)
-        y = temp[np.arange(m), i]
         dfdy = np.zeros_like(x)
         for j in np.unique(i):
             c = i == j
@@ -2510,7 +2508,7 @@ class LowerEnvelope3D(HARKinterpolator3D):
         return dfdz
 
 
-class VariableLowerBoundFunc2D(MetricObject):
+class VariableLowerBoundFunc2D(HARKinterpolator2D):
     """
     A class for representing a function with two real inputs whose lower bound
     in the first input depends on the second input.  Useful for managing curved
@@ -2552,7 +2550,7 @@ class VariableLowerBoundFunc2D(MetricObject):
         f_out = self.func(x - xShift, y)
         return f_out
 
-    def derivativeX(self, x, y):
+    def _derX(self, x, y):
         """
         Evaluate the first derivative with respect to x of the function at given
         state space points.
@@ -2574,7 +2572,7 @@ class VariableLowerBoundFunc2D(MetricObject):
         dfdx_out = self.func.derivativeX(x - xShift, y)
         return dfdx_out
 
-    def derivativeY(self, x, y):
+    def _derY(self, x, y):
         """
         Evaluate the first derivative with respect to y of the function at given
         state space points.
@@ -2599,7 +2597,7 @@ class VariableLowerBoundFunc2D(MetricObject):
         return dfdy_out
 
 
-class VariableLowerBoundFunc3D(MetricObject):
+class VariableLowerBoundFunc3D(HARKinterpolator3D):
     """
     A class for representing a function with three real inputs whose lower bound
     in the first input depends on the second input.  Useful for managing curved
@@ -2643,7 +2641,7 @@ class VariableLowerBoundFunc3D(MetricObject):
         f_out = self.func(x - xShift, y, z)
         return f_out
 
-    def derivativeX(self, x, y, z):
+    def _derX(self, x, y, z):
         """
         Evaluate the first derivative with respect to x of the function at given
         state space points.
@@ -2667,7 +2665,7 @@ class VariableLowerBoundFunc3D(MetricObject):
         dfdx_out = self.func.derivativeX(x - xShift, y, z)
         return dfdx_out
 
-    def derivativeY(self, x, y, z):
+    def _derY(self, x, y, z):
         """
         Evaluate the first derivative with respect to y of the function at given
         state space points.
@@ -2693,7 +2691,7 @@ class VariableLowerBoundFunc3D(MetricObject):
         ) - xShiftDer * self.func.derivativeX(x - xShift, y, z)
         return dfdy_out
 
-    def derivativeZ(self, x, y, z):
+    def _derZ(self, x, y, z):
         """
         Evaluate the first derivative with respect to z of the function at given
         state space points.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,11 +24,11 @@ I got nothing to say
 
 -
 -
--
+- All interpolator classes now have default derivative methods using finite differences. These are fallback methods, and are already overridden by most subclasses. #1723
 
 #### Minor Changes
 
--
+- The _derY method for `LowerEnvelope2D` and `LowerEnvelope3D` were previously bugged and returned nonsense, now fixed. #1723
 -
 -
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -26,10 +26,13 @@ from HARK.interpolation import (
     ValueFuncCRRA,
     MargValueFuncCRRA,
     MargMargValueFuncCRRA,
+    HARKinterpolator1D,
 )
 
 import numpy as np
 import unittest
+
+from tests import HARK_PRECISION
 
 
 class TestInterp1D(unittest.TestCase):
@@ -72,20 +75,26 @@ class TestInterp1D(unittest.TestCase):
     def test_der(self):
         if self.interpolant is None:
             return
-        # Doesn't actually check values of derivative, just whether it runs
-        # and whether they are all real values
+
         derivs = self.interpolant.derivative(self.test_vals)
+        checks = HARKinterpolator1D._der(self.interpolant, self.test_vals)
+
         self.assertTrue(np.all(np.logical_not(np.isnan(derivs))))
         self.assertTrue(np.all(np.logical_not(np.isinf(derivs))))
+        np.testing.assert_allclose(derivs, checks, 1e-5)
 
     def test_eval_and_der(self):
         if self.interpolant is None:
             return
         output = self.interpolant(self.test_vals)
         vals, ders = self.interpolant.eval_with_derivative(self.test_vals)
+        checks, d_checks = HARKinterpolator1D._evalAndDer(
+            self.interpolant, self.test_vals
+        )
         self.assertTrue(np.all(np.logical_not(np.isnan(ders))))
         self.assertTrue(np.all(np.logical_not(np.isinf(ders))))
         self.assertTrue(np.all(np.isclose(output, vals)))
+        np.testing.assert_almost_equal(ders, d_checks, HARK_PRECISION)
 
 
 class TestInterp2D(unittest.TestCase):
@@ -131,20 +140,26 @@ class TestInterp2D(unittest.TestCase):
     def test_derX(self):
         if self.interpolant is None:
             return
-        # Doesn't actually check values of derivative, just whether it runs
-        # and whether they are all real values
+
         derivs = self.interpolant.derivativeX(*self.test_vals)
+        base = type(self.interpolant).__bases__[-1]
+        checks = base._derX(self.interpolant, *self.test_vals)
+
         self.assertTrue(np.all(np.logical_not(np.isnan(derivs))))
         self.assertTrue(np.all(np.logical_not(np.isinf(derivs))))
+        np.testing.assert_almost_equal(derivs, checks, HARK_PRECISION)
 
     def test_derY(self):
         if self.interpolant is None:
             return
-        # Doesn't actually check values of derivative, just whether it runs
-        # and whether they are all real values
+
         derivs = self.interpolant.derivativeY(*self.test_vals)
+        base = type(self.interpolant).__bases__[-1]
+        checks = base._derY(self.interpolant, *self.test_vals)
+
         self.assertTrue(np.all(np.logical_not(np.isnan(derivs))))
         self.assertTrue(np.all(np.logical_not(np.isinf(derivs))))
+        np.testing.assert_almost_equal(derivs, checks, HARK_PRECISION)
 
 
 class TestInterp3D(TestInterp2D):
@@ -176,11 +191,14 @@ class TestInterp3D(TestInterp2D):
     def test_derZ(self):
         if self.interpolant is None:
             return
-        # Doesn't actually check values of derivative, just whether it runs
-        # and whether they are all real values
+
         derivs = self.interpolant.derivativeZ(*self.test_vals)
+        base = type(self.interpolant).__bases__[-1]
+        checks = base.derivativeZ(self.interpolant, *self.test_vals)
+
         self.assertTrue(np.all(np.logical_not(np.isnan(derivs))))
         self.assertTrue(np.all(np.logical_not(np.isinf(derivs))))
+        np.testing.assert_almost_equal(derivs, checks, HARK_PRECISION)
 
 
 class TestInterp4D(TestInterp3D):


### PR DESCRIPTION
Until now, the base interpolator classes `HARKinterpolator1D` through `HARKinterpolator4D` had dummy methods for `_derX` (etc) that simply raised a `NotImplementedError`, with a comment that subclasses should implement their own derivatives.

This PR adds default or fallback derivative methods using finite difference approximation. Subclasses can still override these, but *something* exists for these methods no matter what now. Tests have been added to compare the finite difference methods against class-specific methods.

This PR also fixes two small bugs that I found when implementing it:

1) Two interpolator classes inherited from `MetricObject` rather than `HARKinterpolatorND`.

2) There was an errant line in the `_derY` method of two classes that made the results completely wrong. Like, I have no idea why it would be there.