### PR TITLE
Pin numpy at 2.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ legacy-cgi; python_version >= '3.13'
 matplotlib>=3.6
 networkx>=3
 numba
-numpy
+numpy<=2.4.1
 optimagic
 pandas>=1.5
 pyyaml>=6.0


### PR DESCRIPTION
This is to see if the Estimagic failure is due to numpy 2.4.2. Don't merge.