### PR TITLE
Remove vestigial references to PortfolioBool

### DIFF
--- a/HARK/ConsumptionSaving/ConsBequestModel.py
+++ b/HARK/ConsumptionSaving/ConsBequestModel.py
@@ -1275,7 +1275,6 @@ init_portfolio_bequest = {
     "CubicBool": False,  # Whether to use cubic spline interpolation when True
     # (Uses linear spline interpolation for cFunc when False)
     "IndepDstnBool": True,  # Indicator for whether return & income shocks are independent
-    "PortfolioBool": True,  # Whether this agent has portfolio choice
     "PortfolioBisect": False,  # What does this do?
     "AdjustPrb": 1.0,  # Probability that the agent can update their risky portfolio share each period
     "ShareAugFac": 0,  # Number of times to "zoom in" for an "augmented" search for optimal risky share

--- a/HARK/ConsumptionSaving/ConsWealthPortfolioModel.py
+++ b/HARK/ConsumptionSaving/ConsWealthPortfolioModel.py
@@ -471,7 +471,6 @@ WealthPortfolioConsumerType_solving_default = {
     "WealthShare": 0.5,  # Share of wealth in Cobb-Douglas aggregator in utility function
     "WealthShift": 0.1,  # Shifter for wealth in utility function
     "DiscreteShareBool": False,  # Whether risky asset share is restricted to discrete values
-    "PortfolioBool": True,  # Whether there is portfolio choice
     "PortfolioBisect": False,  # This is a mystery parameter
     "IndepDstnBool": True,  # Whether income and return shocks are independent
     "vFuncBool": False,  # Whether to calculate the value function during solution

--- a/examples/ConsPortfolioModel/RiskyAssetConsumerType.ipynb
+++ b/examples/ConsPortfolioModel/RiskyAssetConsumerType.ipynb
@@ -326,7 +326,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Solving a consumer with idiosyncratic shocks took 1.3893 seconds.\n"
+      "Solving a consumer with idiosyncratic shocks took 1.3331 seconds.\n"
      ]
     }
    ],
@@ -355,7 +355,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Solving a consumer with risky returns took 1.7591 seconds.\n"
+      "Solving a consumer with risky returns took 1.7284 seconds.\n"
      ]
     }
    ],
@@ -385,13 +385,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Solving a consumer with risky returns and portfolio choice took 2.6296 seconds.\n"
+      "Solving a consumer with risky returns and portfolio choice took 2.5810 seconds.\n"
      ]
     }
    ],
    "source": [
     "# Make and solve an example risky consumer with a portfolio choice\n",
-    "my_params[\"PortfolioBool\"] = True\n",
+    "my_params[\"RiskyShareFixed\"] = None\n",
     "PortfolioChoiceExample = RiskyAssetConsumerType(**my_params)\n",
     "t0 = time()\n",
     "PortfolioChoiceExample.solve()\n",

--- a/examples/ConsWealthPortfolioModel/WealthPortfolioConsumerType.ipynb
+++ b/examples/ConsWealthPortfolioModel/WealthPortfolioConsumerType.ipynb
@@ -124,7 +124,7 @@
    "source": [
     "The method for finding optimal consumption for a `WealthPortfolioConsumerType` follows the same procedure as a `WealthUtilityConsumerType`, so the parameters include the primitive values to construct the interpolant `ChiFromOmegaFunction`.\n",
     "\n",
-    "**NB:** For compatibility reasons (related to class inheritance), the `WealthPortfolioConsumerType` also has default parameter values for `DiscreteShareBool`, `PortfolioBool`, `PortfolioBisect`, `IndepDstnBool`, `vFuncBool`, `CubicBool`, `AdjustPrb`, `ShareAugFac`, and `RiskyShareFixed`. These parameters are never referenced and have no effect on the model, but must exist. This issue will be rectified soon."
+    "**NB:** For compatibility reasons (related to class inheritance), the `WealthPortfolioConsumerType` also has default parameter values for `DiscreteShareBool`, `PortfolioBisect`, `IndepDstnBool`, `vFuncBool`, `CubicBool`, `AdjustPrb`, `ShareAugFac`, and `RiskyShareFixed`. These parameters are never referenced and have no effect on the model, but must exist. This issue will be rectified soon."
    ]
   },
   {

--- a/examples/SequenceSpaceJacobians/SSJ-advanced-examples.ipynb
+++ b/examples/SequenceSpaceJacobians/SSJ-advanced-examples.ipynb
@@ -800,7 +800,7 @@
     "from HARK.ConsumptionSaving.ConsRiskyAssetModel import RiskyAssetConsumerType\n",
     "\n",
     "my_risky_params = {\n",
-    "    \"PortfolioBool\": True,\n",
+    "    \"RiskyShareFixed\": None,\n",
     "    \"Rfree\": [1.0],\n",
     "    \"RiskyAvg\": 1.03,\n",
     "    \"RiskyStd\": 0.26,\n",

--- a/tests/ConsumptionSaving/test_ConsRiskyAssetModel.py
+++ b/tests/ConsumptionSaving/test_ConsRiskyAssetModel.py
@@ -70,7 +70,9 @@ class testNonIndeptRiskyAssetConsumerType(unittest.TestCase):
 
 class testPortChoiceConsumerType(unittest.TestCase):
     def setUp(self):
-        self.agent = IndShockRiskyAssetConsumerType(vFuncBool=True, PortfolioBool=True)
+        self.agent = IndShockRiskyAssetConsumerType(
+            vFuncBool=True, RiskyShareFixed=None
+        )
         self.agent.solve()
 
     def test_solution(self):
@@ -95,7 +97,7 @@ class testNonIndepPortChoiceConsumerType(unittest.TestCase):
     def setUp(self):
         self.agent = IndShockRiskyAssetConsumerType(
             IndepDstnBool=False,
-            PortfolioBool=True,
+            RiskyShareFixed=None,
             vFuncBool=True,
         )
         self.agent.solve()


### PR DESCRIPTION
Among a broader documentation expansion, #1740 deprecated the parameter `PortfolioBool`, which was duplicative with setting `RiskyShareFixed=None`. However, I missed a few places where the old parameter was referenced (but not necessarily used).

The main functional change is that this PR reactivates solver tests that were mistakenly bypassed. Because I didn't adjust a couple lines in a test file, the "basic" portfolio choice solver was not being used in the tests for the past week or two.