### PR TITLE
Add "impulse response" function using matrix transition methods

### DIFF
--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -1846,14 +1846,16 @@ class AgentSimulator:
             Names of one or more outcome variables
         T : int
             Number of periods to simulate after the shock.
-        shock : [(str, float)], optional
-            List of pairs of continuation variable name (and operator) and shock value.
-            The first element of each pair should be the name of an arrival variable
-            followed immediately by either + or *. The second element in each pair
-            is the value to apply to the variable via the operator. For example, the
-            pair ("aNrm+", 0.1) means that 0.1 should be added to (the distribution
-            of) end-of-period assets, while ("pLvl*", 0.8) means that permanent
-            income should be reduced by 20% for the entire population. Not all arrival
+        shock : str or [str], optional
+            One or more of "shock operations" to be applied to the steady state
+            (or custom distribution, if specified). Each shock operation should
+            name a continuation variable (something named on the left side of
+            the twist), and be followed by an operator and a value. At this time,
+            the only valid operators are "+", "*", and "=". For example, the shock
+            "aNrm + 0.1" means that 0.1 should be added to (the distribution of
+            end-of-period assets, while "pLvl * 0.8" means that permanent income
+            should be reduced by 20% for the entire population. The "=" operator
+            shifts the entire population to the specified value. Not all arrival
             variables must be named in this argument. Indeed, none need be named.
         from_dstn : np.array, optional
             If provided, a user-specified distribution of arrival states. If none is
@@ -1884,7 +1886,8 @@ class AgentSimulator:
             )
         if shock is None:
             shock = []
-        shock_vars = [S[0][:-1] for S in shock]
+        if type(shock) is str:
+            shock = [shock]
         if isinstance(outcomes, str):
             outcomes = [outcomes]
 
@@ -1896,25 +1899,54 @@ class AgentSimulator:
         else:
             init_dstn = from_dstn
 
-        # Make dynamic event strings for each arrival/continuation variable
+        # Make dynamic event strings for each shock statement
         event_strings = []
-        for k in range(len(self.twist)):
-            var = list(self.twist.keys())[k]
+        shock_vars = []
+        op_list = ["+", "*", "="]
+        for k in range(len(shock)):
+            # Parse the shock statement for its parts
+            S = shock[k]
+            op = None
+            for j in range(len(op_list)):
+                if op_list[j] in S:
+                    op = op_list[j]
+                    break
+            if op is None:
+                raise ValueError(
+                    "The shock statement (" + S + ") did not contain a valid operator!"
+                )
+            loc = S.index(op)
+            var = S[:loc].strip()
+            val = S[(loc + 1) :].strip()
+            if var not in self.twist:
+                raise KeyError(
+                    "All shocked variables must be continuation states, but "
+                    + var
+                    + " is not!"
+                )
+            try:
+                float(val)
+            except:
+                raise ValueError("Couldn't interpret " + val + " as a number!")
+
+            # Make a string for this shock event
+            var_alt = var_alt = self.twist[var]
+            if op == "+":
+                this_event = var + " = " + var_alt + " + " + val
+            elif op == "*":
+                this_event = var + " = " + var_alt + " * " + val
+            elif op == "=":
+                this_event = var + " = " + val
+            event_strings.append(this_event)
+            shock_vars.append(var)
+
+        # For any continuation states that weren't shocked, make a trivial event
+        cont_vars = list(self.twist.keys())
+        for k in range(len(cont_vars)):
+            var = cont_vars[k]
             if var in shock_vars:
-                i = shock_vars.index(var)
-                op = shock[i][0][-1]
-                val = shock[i][1]
-                var_alt = self.twist[var]
-                if op not in ["+", "*"]:
-                    raise ValueError(
-                        "Only addition and multiplication can be specified as shock operations!"
-                    )
-                if op == "+":
-                    this_event = var + " = " + var_alt + " + " + str(val)
-                if op == "*":
-                    this_event = var + " = " + var_alt + " * " + str(val)
-            else:
-                this_event = var + " = " + var_alt
+                continue
+            this_event = var + " = " + var_alt
             event_strings.append(this_event)
 
         # Extract grid specifications only for arrival and continuation variables

--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -1857,6 +1857,8 @@ class AgentSimulator:
             should be reduced by 20% for the entire population. The "=" operator
             shifts the entire population to the specified value. Not all arrival
             variables must be named in this argument. Indeed, none need be named.
+            The numeric value should *not* use scientific notation nor other math
+            operations; e.g. use "0.0001" and not "1e-4".
         from_dstn : np.array, optional
             If provided, a user-specified distribution of arrival states. If none is
             given (typical), then the steady state distribution is used. Any shocks

--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -979,6 +979,9 @@ class SimBlock:
         - grids : A dictionary of discretized grids for outcome variables. Doing
                   np.dot(np.dot(dstn, matrices[var]), grids[var]) yields the *average*
                   of that outcome in the population.
+        - trans_array : The full-period Markov transitition matrix that goes from
+                        arrival variables in t to arrival variables in t+1, including
+                        mortality.
 
         Parameters
         ----------
@@ -1018,7 +1021,7 @@ class SimBlock:
         # Make meshes of all the arrival grids, which will be the initial simulation data
         if arrival_N > 0:
             state_meshes = np.meshgrid(
-                *[grids_in[k] for k in self.arrival], indexing="ij"
+                *[grids_in[var] for var in self.arrival], indexing="ij"
             )
         else:  # this only happens in the initializer block
             state_meshes = [dummy_grid.copy()]
@@ -1565,6 +1568,8 @@ class AgentSimulator:
                 grid_specs_other, twist=self.twist, norm=norm
             )
             block.reset()
+        self.grid_specs = grid_specs_other
+        self.norm = norm
 
         # Extract the master transition matrices into a single list
         p2p_trans_arrays = [block.trans_array for block in self.periods]
@@ -1623,6 +1628,30 @@ class AgentSimulator:
         SS_dstn = (D / np.sum(D)).real
         self.steady_state_dstn = SS_dstn
 
+    def get_long_run_dstn(self, var):
+        """
+        Calculate and return the long run / steady state population distribution
+        of one named variable. Should only be run after find_steady_state().
+
+        Parameters
+        ----------
+        var : str
+            Name of the variable for which to calculate the long run average.
+
+        Returns
+        -------
+        var_dstn : np.array
+            Long run / steady state population distribution of the variable,
+            as a stochastic vector defined on the variable's discretized grid.
+        """
+        if not hasattr(self, "steady_state_dstn"):
+            raise ValueError("This method can only be run after find_steady_state()!")
+
+        dstn = self.steady_state_dstn
+        array = self.outcome_arrays[0][var]
+        var_dstn = np.dot(dstn, array)
+        return var_dstn
+
     def get_long_run_average(self, var):
         """
         Calculate and return the long run / steady state population average of
@@ -1638,14 +1667,8 @@ class AgentSimulator:
         var_mean : float
             Long run / steady state population average of the variable.
         """
-        if not hasattr(self, "steady_state_dstn"):
-            raise ValueError("This method can only be run after find_steady_state()!")
-
-        dstn = self.steady_state_dstn
-        array = self.outcome_arrays[0][var]
+        var_dstn = self.get_long_run_dstn(var)
         grid = self.outcome_grids[0][var]
-
-        var_dstn = np.dot(dstn, array)
         var_mean = np.dot(var_dstn, grid)
         return var_mean
 
@@ -1797,6 +1820,147 @@ class AgentSimulator:
 
         # Return the output
         return state_targ
+
+    def simulate_shock_by_grids(
+        self,
+        outcomes,
+        T,
+        shock=None,
+        from_dstn=None,
+        calc_dstn=False,
+        calc_avg=True,
+    ):
+        """
+        Generate the time series of population outcomes in response to an unexpected
+        shock. The shock can be specified as additive or multiplicative events that
+        are applied to the steady state distribution of arrival states, or as a user-
+        specified distribution of arrival states. This method is intended only for
+        infinite horizon, single period models. Stores results in the dictionary
+        attributes history_avg and history_dstn respectively.
+
+        This method can only be run after running make_transition_matrices.
+
+        Parameters
+        ----------
+        outcomes : str or [str]
+            Names of one or more outcome variables
+        T : int
+            Number of periods to simulate after the shock.
+        shock : [(str, float)], optional
+            List of pairs of continuation variable name (and operator) and shock value.
+            The first element of each pair should be the name of an arrival variable
+            followed immediately by either + or *. The second element in each pair
+            is the value to apply to the variable via the operator. For example, the
+            pair ("aNrm+", 0.1) means that 0.1 should be added to (the distribution
+            of) end-of-period assets, while ("pLvl*", 0.8) means that permanent
+            income should be reduced by 20% for the entire population. Not all arrival
+            variables must be named in this argument. Indeed, none need be named.
+        from_dstn : np.array, optional
+            If provided, a user-specified distribution of arrival states. If none is
+            given (typical), then the steady state distribution is used. Any shocks
+            described in shock are applied to this initial distribution.
+        calc_dstn : bool, optional
+            Whether to store the distribution of the outcomes over time in history_dstn.
+            The default is False.
+        calc_avg : bool, optional
+            Whether to store the population average of the outcomes over time in
+            history_avg. The default is True
+
+        Returns
+        -------
+        None.
+        """
+        if not (calc_dstn or calc_avg):
+            raise ValueError(
+                "At least one of calc_dstn or calc_avg must be true, or there's no work!"
+            )
+        if (shock is None) and (from_dstn is None):
+            raise ValueError(
+                "The shock or from_dstn must be specified, or there's nothing to simulate!"
+            )
+        if not hasattr(self, "trans_arrays"):
+            raise KeyError(
+                "This method can't be run before running make_transition_arrays!"
+            )
+        if shock is None:
+            shock = []
+        shock_vars = [S[0][:-1] for S in shock]
+        if isinstance(outcomes, str):
+            outcomes = [outcomes]
+
+        # Get the starting unperturbed distribution
+        if from_dstn is None:
+            if not hasattr(self, "steady_state_dstn"):
+                self.find_steady_state()
+            init_dstn = self.steady_state_dstn
+        else:
+            init_dstn = from_dstn
+
+        # Make dynamic event strings for each arrival/continuation variable
+        event_strings = []
+        for k in range(len(self.twist)):
+            var = list(self.twist.keys())[k]
+            if var in shock_vars:
+                i = shock_vars.index(var)
+                op = shock[i][0][-1]
+                val = shock[i][1]
+                var_alt = self.twist[var]
+                if op not in ["+", "*"]:
+                    raise ValueError(
+                        "Only addition and multiplication can be specified as shock operations!"
+                    )
+                if op == "+":
+                    this_event = var + " = " + var_alt + " + " + str(val)
+                if op == "*":
+                    this_event = var + " = " + var_alt + " * " + str(val)
+            else:
+                this_event = var + " = " + var_alt
+            event_strings.append(this_event)
+
+        # Extract grid specifications only for arrival and continuation variables
+        grid_specs_temp = {}
+        for var in self.grid_specs:
+            if (var in self.twist) or (var in self.periods[0].arrival):
+                grid_specs_temp[var] = self.grid_specs[var]
+
+        # Make a fake model block that applies the shock
+        shock_model = {"name": "exogenous shock", "dynamics": event_strings}
+        shock_block, info, offset, solution, comments = make_template_block(
+            shock_model, arrival=self.periods[0].arrival
+        )
+        shock_block.make_transition_matrices(grid_specs_temp, twist=self.twist)
+        shock_block.reset()
+
+        # Apply the shock transition to the starting distribution
+        init_dstn = np.dot(init_dstn, shock_block.trans_array)
+
+        # Initialize generated output
+        history_dstn = {}
+        history_avg = {}
+
+        # Initialize the state distribution
+        current_dstn = init_dstn.copy()
+        state_dstn_by_t = np.empty((current_dstn.size, T))
+        trans_array = self.trans_arrays[0]
+
+        # Loop over requested periods of this agent type's model
+        for t in range(T):
+            state_dstn_by_t[:, t] = current_dstn
+            current_dstn = np.dot(current_dstn, trans_array)
+
+        # Calculate history of outcomes as requested
+        for name in outcomes:
+            this_outcome = self.outcome_arrays[0][name]
+            this_dstn = np.dot(this_outcome.T, state_dstn_by_t)
+            if calc_dstn:
+                history_dstn[name] = this_dstn
+            if calc_avg:
+                this_grid = self.outcome_grids[0][name]
+                history_avg[name] = np.dot(this_grid, this_dstn)
+
+        # Store results as attributes of self
+        self.history_dstn = history_dstn
+        self.history_avg = history_avg
 
     def simulate_cohort_by_grids(
         self,
@@ -3368,7 +3532,7 @@ def parse_random_indexed(expression):
 
 def format_block_statement(statement):
     """
-    Ensure that a string stagement of a model block (maybe a period, maybe an
+    Ensure that a string statement of a model block (maybe a period, maybe an
     initializer) is formatted as a list of strings, one statement per entry.
 
     Parameters
@@ -3446,7 +3610,7 @@ def aggregate_blobs_onto_polynomial_grid_alt(
     """
     Numba-compatible helper function for casting "probability blobs" onto a discretized
     grid of outcome values, based on their origin in the arrival state space. This
-    version is for ncontinuation variables, returning the probability array mapping
+    version is for continuation variables, returning the probability array mapping
     from arrival states to the outcome variable, the index in the outcome variable grid
     for each blob, and the alpha weighting between gridpoints.
     """
@@ -3491,14 +3655,14 @@ def aggregate_blobs_onto_discrete_grid(vals, pmv, origins, M, J):  # pragma: no 
     Numba-compatible helper function for allocating "probability blobs" to a grid
     over a discrete state-- the state itself is truly discrete.
     """
-    out = np.zeros((J, M))
+    probs = np.zeros((J, M))
     N = pmv.size
     for n in range(N):
         ii = vals[n]
         jj = origins[n]
         p = pmv[n]
-        out[jj, ii] += p
-    return out
+        probs[jj, ii] += p
+    return probs
 
 
 @njit

--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -979,7 +979,7 @@ class SimBlock:
         - grids : A dictionary of discretized grids for outcome variables. Doing
                   np.dot(np.dot(dstn, matrices[var]), grids[var]) yields the *average*
                   of that outcome in the population.
-        - trans_array : The full-period Markov transitition matrix that goes from
+        - trans_array : The full-period Markov transition matrix that goes from
                         arrival variables in t to arrival variables in t+1, including
                         mortality.
 
@@ -1880,9 +1880,13 @@ class AgentSimulator:
             raise ValueError(
                 "The shock or from_dstn must be specified, or there's nothing to simulate!"
             )
+        if self.T_total != 1:
+            raise ValueError(
+                "simulate_shock_by_grids is only implemented for infinite-horizon models with T_total == 1."
+            )
         if not hasattr(self, "trans_arrays"):
             raise KeyError(
-                "This method can't be run before running make_transition_arrays!"
+                "This method can't be run before running make_transition_matrices!"
             )
         if shock is None:
             shock = []
@@ -1926,11 +1930,11 @@ class AgentSimulator:
                 )
             try:
                 float(val)
-            except:
+            except (ValueError, TypeError):
                 raise ValueError("Couldn't interpret " + val + " as a number!")
 
             # Make a string for this shock event
-            var_alt = var_alt = self.twist[var]
+            var_alt = self.twist[var]
             if op == "+":
                 this_event = var + " = " + var_alt + " + " + val
             elif op == "*":
@@ -1972,24 +1976,54 @@ class AgentSimulator:
 
         # Initialize the state distribution
         current_dstn = init_dstn.copy()
-        state_dstn_by_t = np.empty((current_dstn.size, T))
+
+        # If we need the full distribution history, allocate state_dstn_by_t;
+        # otherwise, avoid this potentially large O(num_states * T) array.
+        if calc_dstn:
+            state_dstn_by_t = np.empty((current_dstn.size, T))
+        else:
+            state_dstn_by_t = None
+
         trans_array = self.trans_arrays[0]
+
+        # If we only need averages (no full distributions), we can stream
+        # the averages over time without storing the full state history.
+        if calc_avg and not calc_dstn:
+            outcome_arrays_0 = self.outcome_arrays[0]
+            outcome_grids_0 = self.outcome_grids[0]
+            for name in outcomes:
+                history_avg[name] = np.empty(T)
 
         # Loop over requested periods of this agent type's model
         for t in range(T):
-            state_dstn_by_t[:, t] = current_dstn
+            # Store full state distribution history only if requested
+            if calc_dstn:
+                state_dstn_by_t[:, t] = current_dstn
+
+            # Stream averages when only averages are needed
+            if calc_avg and not calc_dstn:
+                for name in outcomes:
+                    this_outcome = outcome_arrays_0[name]
+                    this_grid = outcome_grids_0[name]
+                    this_dstn_t = np.dot(this_outcome.T, current_dstn)
+                    history_avg[name][t] = np.dot(this_grid, this_dstn_t)
+
             current_dstn = np.dot(current_dstn, trans_array)
 
         # Calculate history of outcomes as requested
         for name in outcomes:
             this_outcome = self.outcome_arrays[0][name]
-            this_dstn = np.dot(this_outcome.T, state_dstn_by_t)
-            if calc_dstn:
-                history_dstn[name] = this_dstn
-            if calc_avg:
-                this_grid = self.outcome_grids[0][name]
-                history_avg[name] = np.dot(this_grid, this_dstn)
+            this_grid = self.outcome_grids[0][name]
 
+            if calc_dstn:
+                this_dstn = np.dot(this_outcome.T, state_dstn_by_t)
+                history_dstn[name] = this_dstn
+
+                if calc_avg:
+                    history_avg[name] = np.dot(this_grid, this_dstn)
+            elif calc_avg:
+                # Averages have already been filled in the time loop
+                continue
         # Store results as attributes of self
         self.history_dstn = history_dstn
         self.history_avg = history_avg

--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -1636,7 +1636,7 @@ class AgentSimulator:
         Parameters
         ----------
         var : str
-            Name of the variable for which to calculate the long run average.
+            Name of the variable for which to calculate the long run distribution.
 
         Returns
         -------
@@ -1852,7 +1852,7 @@ class AgentSimulator:
             name a continuation variable (something named on the left side of
             the twist), and be followed by an operator and a value. At this time,
             the only valid operators are "+", "*", and "=". For example, the shock
-            "aNrm + 0.1" means that 0.1 should be added to (the distribution of
+            "aNrm + 0.1" means that 0.1 should be added to (the distribution of)
             end-of-period assets, while "pLvl * 0.8" means that permanent income
             should be reduced by 20% for the entire population. The "=" operator
             shifts the entire population to the specified value. Not all arrival
@@ -1950,6 +1950,7 @@ class AgentSimulator:
             var = cont_vars[k]
             if var in shock_vars:
                 continue
+            var_alt = self.twist[var]
             this_event = var + " = " + var_alt
             event_strings.append(this_event)
 

--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -1936,7 +1936,7 @@ class AgentSimulator:
             elif op == "*":
                 this_event = var + " = " + var_alt + " * " + val
             elif op == "=":
-                this_event = var + " = " + val
+                this_event = var + " = " + var_alt + " * 0.0 + " + val
             event_strings.append(this_event)
             shock_vars.append(var)
 

--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -1864,11 +1864,11 @@ class AgentSimulator:
             given (typical), then the steady state distribution is used. Any shocks
             described in shock are applied to this initial distribution.
         calc_dstn : bool, optional
-            Whether to store the distribution of the outcomes over time in history_dstn.
+            Whether to store the distribution of outcomes over time in history_dstn.
             The default is False.
         calc_avg : bool, optional
             Whether to store the population average of the outcomes over time in
-            history_avg. The default is True
+            history_avg. The default is True.
 
         Returns
         -------
@@ -1903,6 +1903,22 @@ class AgentSimulator:
                 self.find_steady_state()
             init_dstn = self.steady_state_dstn
         else:
+            dstn_sum = np.sum(from_dstn)
+            dstn_N = from_dstn.size
+            if not np.isclose(dstn_sum, 1.0):
+                raise ValueError(
+                    "Specified from_dstn should be a stochastic vector, but its values sum to "
+                    + str(dstn_sum)
+                )
+            arrival_N = len(self.state_grids[0])
+            if not arrival_N == dstn_N:
+                raise ValueError(
+                    "Specified from_dstn should be a vector of size "
+                    + str(arrival_N)
+                    + ", but has size "
+                    + str(dstn_N)
+                    + "!"
+                )
             init_dstn = from_dstn
 
         # Make dynamic event strings for each shock statement

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ There are some breaking changes:
 - The above method calls each `agent`'s `get_market_params()` method, which references the `market_vars` class attribute for the names of objects to take from the associated `Market`.
 - All interpolator classes now have default derivative methods using finite differences. These are fallback methods, and are already overridden by most subclasses. #1723
 - New consumption-saving model with habit formation has been added; extends IndShockConsumerType model. #1739
-- Simulator class has new method `simulate_shock_by_grids` to perturb the steady state distribution and then simulate by matrix transition methods. #XXXX
+- Simulator class has new method `simulate_shock_by_grids` to perturb the steady state distribution and then simulate by matrix transition methods. #1754
 
 #### Minor Changes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ There are some breaking changes:
 - The above method calls each `agent`'s `get_market_params()` method, which references the `market_vars` class attribute for the names of objects to take from the associated `Market`.
 - All interpolator classes now have default derivative methods using finite differences. These are fallback methods, and are already overridden by most subclasses. #1723
 - New consumption-saving model with habit formation has been added; extends IndShockConsumerType model. #1739
+- Simulator class has new method `simulate_shock_by_grids` to perturb the steady state distribution and then simulate by matrix transition methods. #XXXX
 
 #### Minor Changes
 

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -267,6 +267,30 @@ class testSimulatorClass(unittest.TestCase):
         self.assertTrue(np.all(np.isclose(np.sum(A_dstn, axis=0), 1.0)))
         self.assertAlmostEqual(A_avg[-1], A_LR)
 
+    def test_simulate_shock_custom_dstn(self):
+        MyType = IndShockConsumerType(cycles=0)
+        MyType.solve()
+        MyType.initialize_sym()
+        T = 200
+        my_grids = {
+            "kNrm": {"min": 0.0, "max": 30.0, "N": 501, "order": 2.5},
+            "cNrm": {"min": 0.0, "max": 3.0, "N": 301},
+        }
+
+        # Make a rather extreme custom distribution
+        my_dstn = np.zeros(501)
+        my_dstn[0] = 0.5
+        my_dstn[-1] = 0.5
+
+        MyType._simulator.make_transition_matrices(my_grids, norm="PermShk")
+        MyType._simulator.find_steady_state()
+        MyType._simulator.simulate_shock_by_grids("aNrm", T, from_dstn=my_dstn)
+        A_avg = MyType._simulator.history_avg["aNrm"]
+        A_LR = MyType._simulator.get_long_run_average("aNrm")
+        self.assertEqual(A_avg.size, T)
+        self.assertTrue(np.all(np.isreal(A_avg)))
+        self.assertAlmostEqual(A_avg[-1], A_LR)
+
     def test_SSbyG_errors(self):
         MyType = IndShockConsumerType(cycles=0)
         MyType.solve()
@@ -277,7 +301,7 @@ class testSimulatorClass(unittest.TestCase):
             "cNrm": {"min": 0.0, "max": 3.0, "N": 301},
         }
 
-        self.assertRaises(
+        self.assertRaises(  # run before transition matrices exist
             KeyError,
             MyType._simulator.simulate_shock_by_grids,
             ["aNrm"],
@@ -285,10 +309,10 @@ class testSimulatorClass(unittest.TestCase):
             "aNrm * 1.1",
         )
         MyType._simulator.make_transition_matrices(my_grids, norm="PermShk")
-        self.assertRaises(
+        self.assertRaises(  # run without any shock
             ValueError, MyType._simulator.simulate_shock_by_grids, ["aNrm"], T
         )
-        self.assertRaises(
+        self.assertRaises(  # run with no output
             ValueError,
             MyType._simulator.simulate_shock_by_grids,
             ["aNrm"],
@@ -296,26 +320,45 @@ class testSimulatorClass(unittest.TestCase):
             "aNrm * 1.1",
             calc_avg=False,
         )
-        self.assertRaises(
+        self.assertRaises(  # run with invalid operator
             ValueError,
             MyType._simulator.simulate_shock_by_grids,
             ["aNrm"],
             T,
             "aNrm / 1.1",
         )
-        self.assertRaises(
+        self.assertRaises(  # try to use non-continuation state
             KeyError,
             MyType._simulator.simulate_shock_by_grids,
             ["aNrm"],
             T,
             "mNrm * 1.1",
         )
-        self.assertRaises(
+        self.assertRaises(  # try to use invalid number
             ValueError,
             MyType._simulator.simulate_shock_by_grids,
             ["aNrm"],
             T,
             "aNrm * 1.ae1",
+        )
+        bad_grid = np.zeros(501)
+        bad_grid[0] = 0.5
+        self.assertRaises(  # grid doesn't sum to 1
+            ValueError,
+            MyType._simulator.simulate_shock_by_grids,
+            ["aNrm"],
+            T,
+            from_dstn=bad_grid,
+        )
+        bad_grid = np.zeros(502)
+        bad_grid[0] = 0.5
+        bad_grid[-1] = 0.5
+        self.assertRaises(  # grid has wrong size
+            ValueError,
+            MyType._simulator.simulate_shock_by_grids,
+            ["aNrm"],
+            T,
+            from_dstn=bad_grid,
         )
 
 

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -254,7 +254,7 @@ class testSimulatorClass(unittest.TestCase):
 
         MyType._simulator.make_transition_matrices(my_grids, norm="PermShk")
         MyType._simulator.simulate_shock_by_grids(
-            ["aNrm"], T, "aNrm * 1.1", calc_dstn=True
+            "aNrm", T, "aNrm * 1.1", calc_dstn=True
         )
         A_avg = MyType._simulator.history_avg["aNrm"]
         A_dstn = MyType._simulator.history_dstn["aNrm"]

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -242,6 +242,82 @@ class testSimulatorClass(unittest.TestCase):
             self.grid_specs,
         )
 
+    def test_simulate_shock_by_grids(self):
+        MyType = IndShockConsumerType(cycles=0)
+        MyType.solve()
+        MyType.initialize_sym()
+        T = 200
+        my_grids = {
+            "kNrm": {"min": 0.0, "max": 30.0, "N": 501, "order": 2.5},
+            "cNrm": {"min": 0.0, "max": 3.0, "N": 301},
+        }
+
+        MyType._simulator.make_transition_matrices(my_grids, norm="PermShk")
+        MyType._simulator.simulate_shock_by_grids(
+            ["aNrm"], T, "aNrm * 1.1", calc_dstn=True
+        )
+        A_avg = MyType._simulator.history_avg["aNrm"]
+        A_dstn = MyType._simulator.history_dstn["aNrm"]
+        A_LR = MyType._simulator.get_long_run_average("aNrm")
+        self.assertEqual(A_avg.size, T)
+        self.assertEqual(A_dstn.shape[0], 501)
+        self.assertEqual(A_dstn.shape[1], T)
+        self.assertTrue(np.all(np.isreal(A_avg)))
+        self.assertTrue(np.all(np.isreal(A_dstn)))
+        self.assertTrue(np.all(np.isclose(np.sum(A_dstn, axis=0), 1.0)))
+        self.assertAlmostEqual(A_avg[-1], A_LR)
+
+    def test_SSbyG_errors(self):
+        MyType = IndShockConsumerType(cycles=0)
+        MyType.solve()
+        MyType.initialize_sym()
+        T = 200
+        my_grids = {
+            "kNrm": {"min": 0.0, "max": 30.0, "N": 501, "order": 2.5},
+            "cNrm": {"min": 0.0, "max": 3.0, "N": 301},
+        }
+
+        self.assertRaises(
+            KeyError,
+            MyType._simulator.simulate_shock_by_grids,
+            ["aNrm"],
+            T,
+            "aNrm * 1.1",
+        )
+        MyType._simulator.make_transition_matrices(my_grids, norm="PermShk")
+        self.assertRaises(
+            ValueError, MyType._simulator.simulate_shock_by_grids, ["aNrm"], T
+        )
+        self.assertRaises(
+            ValueError,
+            MyType._simulator.simulate_shock_by_grids,
+            ["aNrm"],
+            T,
+            "aNrm * 1.1",
+            calc_avg=False,
+        )
+        self.assertRaises(
+            ValueError,
+            MyType._simulator.simulate_shock_by_grids,
+            ["aNrm"],
+            T,
+            "aNrm / 1.1",
+        )
+        self.assertRaises(
+            KeyError,
+            MyType._simulator.simulate_shock_by_grids,
+            ["aNrm"],
+            T,
+            "mNrm * 1.1",
+        )
+        self.assertRaises(
+            ValueError,
+            MyType._simulator.simulate_shock_by_grids,
+            ["aNrm"],
+            T,
+            "aNrm * 1.ae1",
+        )
+
 
 class testFindTarget(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The `AgentSimulator` class now has a `simulate_shock_by_grids` method that can be run after `make_transition_matrices`. The gist is that you can perturb the long run / steady state distribution in some way, then use matrix transition methods to compute the time series of average outcomes (can also make distributions). Example syntax:

`MyType = IndShockConsumerType(cycles=0)`
`MyType.solve()`
`MyType.initialize_sym()`
`my_grids = {"kNrm": {"min" : 0.0, "max" : 30.0, "N" : 501, "order" : 2.5}, "cNrm" : {"min" : 0.0, "max" : 3.0, "N" : 301}}`
`MyType._simulator.make_transition_matrices(my_grids, norm="PermShk")`
`MyType._simulator.simulate_shock_by_grids(["aNrm", "cNrm"], 200, "aNrm * 1.1")`

This will multiply the long run distribution of $a_t$ (really $k_t$) by 1.1, then grid-simulate for 200 periods. The dictionary attribute `history_avg` will have time-series entries for `aNrm` and `cNrm`, just like it would for `simulate_cohort_by_grids`.

New tests should cover all new lines of code.