### PR TITLE
Reproduce #1755: Add link to KS explanation notebook

### DIFF
--- a/examples/SequenceSpaceJacobians/SSJ_explanation.ipynb
+++ b/examples/SequenceSpaceJacobians/SSJ_explanation.ipynb
@@ -336,7 +336,7 @@
    "source": [
     "## Solving Using the HANK-SSJ Link\n",
     "\n",
-    "A companion notebook, `KS-HARK-presentation` presents the solution to the model described above using the HARK toolkit in combination with the SSJ toolkit."
+    "A [companion notebook](KS-HARK-presentation.ipynb) presents the solution to the model described above using the HARK toolkit in combination with the SSJ toolkit."
    ]
   }
  ],
@@ -356,7 +356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
PR #1755 only made one small change, but it was somehow corrupted. This PR reproduces that one change by adding a link to one notebook.