### PR TITLE
Add missing language about "flat" population dynamics to LC-SSJ notebook

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,27 @@ For more information on HARK, see [our Github organization](https://github.com/e
 
 ## Changes
 
+### 0.17.3 (dev)
+
+Release Date: TBD
+
+#### Release Notes
+
+(None yet)
+
+#### Major Changes
+
+- future item
+- future item
+- future item
+
+#### Minor Changes
+
+- future item
+- future item
+- future item
+
+
 ### 0.17.2
 
 Release Date: May 1, 2026
@@ -69,6 +90,7 @@ There are some breaking changes:
 - `HARK.simulator` and experimental Monte Carlo submodule refactored to reduce repetition. #1766
 - `HARK.distributions` refactored to reduce repetition and improve structures. #1767
 - Additional refactoring in `Labeled`, `SSJutils`, `utilities`, and `metric` to reduce code repetition. #1768
+
 
 ### 0.17.1
 

--- a/examples/SequenceSpaceJacobians/SSJ-lifecycle.ipynb
+++ b/examples/SequenceSpaceJacobians/SSJ-lifecycle.ipynb
@@ -29,9 +29,25 @@
    "id": "94654ac0-e47f-4713-870b-381e60aed28f",
    "metadata": {},
    "source": [
-    "The \"sequence space Jacobian\" approach, first [described by Auclert et al (2021)](https://onlinelibrary.wiley.com/doi/full/10.3982/ECTA17434), has rapidly become quite popular in heterogeneous agents macroeconomics. While the original paper only laid out how to construct HA-SSJ matrices (with the \"fake news\" algorithm) for standard infinite horizon or perpetual youth models, one of its authors has very recently teamed up with friend of Econ-ARK Velasquez-Giraldo to [extend the algorithm](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5274675) to life-cycle models.\n",
+    "The \"sequence space Jacobian\" approach, first [described by Auclert et al (2021)](https://onlinelibrary.wiley.com/doi/full/10.3982/ECTA17434), has rapidly become quite popular in heterogeneous agents macroeconomics. While the original paper only laid out how to construct HA-SSJ matrices (with the \"fake news\" algorithm) for standard infinite horizon or perpetual youth models, one of its authors has very recently teamed up with Econ-ARK contributor Mateo Velasquez-Giraldo to [extend the algorithm](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5274675) to life-cycle models.\n",
     "\n",
     "This new HA-SSJ capability for life-cycle models has been incorporated into HARK, using the same `make_basic_SSJ` interface as for standard infinite horizon models. If you haven't already, we recommend that you read our [basic SSJ tutorial](SSJ-tutorial.ipynb) notebook before going further here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec58291a-d00b-4618-b68f-a46aaf37232f",
+   "metadata": {},
+   "source": [
+    "## Key Restriction: \"Flat\" Population Dynamics\n",
+    "\n",
+    "As forewarning, not all life-cycle models are currently compatible with HARK's automatic HA-SSJ computation. The key restriction is that the model's population dynamics must be \"flat\" or invariant to the shock of interest. This means two things.\n",
+    "\n",
+    "First, the model itself cannot have agent survival be endogenous to agent behavior, as in a model with endogenous health through medical care or other choices. For almost any interesting shock, those agent behaviors *will* be affected, and thus population dynamics will be affected by the shock.\n",
+    "\n",
+    "Second, even if survival is exogenous within the microeconomic model, it *also* cannot be perturbed by the shocked variable. For example, `MarkovConsumerType` can be used to specify a model with persistent unemployment in which unemployed agents are less likely to survive to the next period. This model could be used if you were interested in shocks to the interest rate `Rfree` and/or the wage rate `WageRte`. However, if the shock variable involves the *transition probabilities* between employment states, then survival probabilities will be indirectly affected, and thus population dynamics are not \"flat\".\n",
+    "\n",
+    "We are working on generalizing the method so we can lift this restriction."
    ]
   },
   {

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -189,6 +189,7 @@ class testSimulatorClass(unittest.TestCase):
             offset=True,
             norm="PermShk",
             trend="PermGroFac",
+            verbose=True,
         )
 
         self.assertTrue(np.all(np.isreal(J_A_R)))


### PR DESCRIPTION
I forgot to include the section about "flat" population dynamics in the notebook. It was already in the method's docstring. Also fixed Mateo's name.

CHANGELOG has new (blank) version section.