### PR TITLE
Add HARK.interpolation_jax — opt-in JAX counterparts to interpolation primitives

### DIFF
--- a/HARK/interpolation_jax.py
+++ b/HARK/interpolation_jax.py
@@ -1,0 +1,269 @@
+"""
+JAX implementations of HARK interpolation primitives.
+
+This is an opt-in alternative to the numpy/numba implementations in
+``HARK.interpolation``. The functions here are designed for use in JAX-jitted
+solvers (CPU or GPU). They are functional (data + query arguments, no classes)
+so that they can be ``vmap``-ed, ``jit``-ed, and differentiated.
+
+Every function here has a bit-precision counterpart in ``HARK.interpolation``;
+see ``HARK/tests/test_interpolation_jax.py`` for the parity tests.
+
+JAX is an optional dependency. Importing this module without JAX installed
+raises ``ImportError`` with installation instructions.
+"""
+from __future__ import annotations
+
+try:
+    import jax
+    import jax.numpy as jnp
+except ImportError as _e:  # pragma: no cover
+    raise ImportError(
+        "HARK.interpolation_jax requires JAX. "
+        "Install with: pip install jax  (or: pip install 'jax[cuda12]' for GPU)"
+    ) from _e
+
+
+# ============================================================
+# 1-D linear interpolation — counterpart to HARK.interpolation.LinearInterp
+# ============================================================
+
+def linear_interp_1d(x_grid, y_vals, x_query, lower_extrap=False):
+    """
+    1-D linear interpolation, matching ``HARK.interpolation.LinearInterp``
+    with ``decay_extrap=False`` (the default).
+
+    Parameters
+    ----------
+    x_grid : array_like, shape (N,)
+        Sorted strictly-increasing grid of x values.
+    y_vals : array_like, shape (N,)
+        Function values at the grid points.
+    x_query : array_like
+        Query x values (any shape).
+    lower_extrap : bool, default False
+        If False, queries below ``x_grid[0]`` return NaN (matches HARK default).
+        If True, linear extrapolation is used at both ends.
+
+    Returns
+    -------
+    array_like
+        Interpolated y values, same shape as ``x_query``.
+
+    Notes
+    -----
+    Mirrors HARK semantics exactly: ``searchsorted`` is run on ``x_grid[:-1]``,
+    so above-top queries hit segment (N-2, N-1) and receive linear
+    extrapolation rather than NaN regardless of ``lower_extrap``.
+    """
+    x_grid = jnp.asarray(x_grid)
+    y_vals = jnp.asarray(y_vals)
+    n = x_grid.shape[0]
+    i = jnp.clip(jnp.searchsorted(x_grid[:-1], x_query, side='left'), 1, n - 1)
+    alpha = (x_query - x_grid[i - 1]) / (x_grid[i] - x_grid[i - 1])
+    y = (1 - alpha) * y_vals[i - 1] + alpha * y_vals[i]
+    if not lower_extrap:
+        y = jnp.where(x_query < x_grid[0], jnp.nan, y)
+    return y
+
+
+# ============================================================
+# 2-D bilinear interpolation — counterpart to HARK.interpolation.BilinearInterp
+# ============================================================
+
+def bilinear_interp(f_values, x_grid, y_grid, x_query, y_query):
+    """
+    2-D bilinear interpolation, matching ``HARK.interpolation.BilinearInterp``.
+
+    Parameters
+    ----------
+    f_values : array_like, shape (Nx, Ny)
+        ``f_values[i, j] = f(x_grid[i], y_grid[j])``.
+    x_grid : array_like, shape (Nx,)
+    y_grid : array_like, shape (Ny,)
+    x_query, y_query : array_like
+        Query points, same shape.
+
+    Returns
+    -------
+    array_like
+        Interpolated values, same shape as ``x_query``.
+
+    Notes
+    -----
+    HARK clips both directions to a valid segment, so queries outside the grid
+    extrapolate using the boundary segment.
+    """
+    f_values = jnp.asarray(f_values)
+    x_grid = jnp.asarray(x_grid)
+    y_grid = jnp.asarray(y_grid)
+    Nx = x_grid.shape[0]
+    Ny = y_grid.shape[0]
+    x_pos = jnp.clip(jnp.searchsorted(x_grid, x_query, side='left'), 1, Nx - 1)
+    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side='left'), 1, Ny - 1)
+    alpha = (x_query - x_grid[x_pos - 1]) / (x_grid[x_pos] - x_grid[x_pos - 1])
+    beta = (y_query - y_grid[y_pos - 1]) / (y_grid[y_pos] - y_grid[y_pos - 1])
+    f00 = f_values[x_pos - 1, y_pos - 1]
+    f01 = f_values[x_pos - 1, y_pos]
+    f10 = f_values[x_pos, y_pos - 1]
+    f11 = f_values[x_pos, y_pos]
+    return ((1 - alpha) * (1 - beta) * f00
+            + (1 - alpha) * beta * f01
+            + alpha * (1 - beta) * f10
+            + alpha * beta * f11)
+
+
+def bilinear_interp_derX(f_values, x_grid, y_grid, x_query, y_query):
+    """
+    Partial derivative ∂f/∂x of bilinear interp, matching
+    ``HARK.interpolation.BilinearInterp.derivativeX``.
+
+    Parameters mirror :func:`bilinear_interp`.
+    """
+    f_values = jnp.asarray(f_values)
+    x_grid = jnp.asarray(x_grid)
+    y_grid = jnp.asarray(y_grid)
+    Nx = x_grid.shape[0]
+    Ny = y_grid.shape[0]
+    x_pos = jnp.clip(jnp.searchsorted(x_grid, x_query, side='left'), 1, Nx - 1)
+    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side='left'), 1, Ny - 1)
+    beta = (y_query - y_grid[y_pos - 1]) / (y_grid[y_pos] - y_grid[y_pos - 1])
+    dfdx = (((1 - beta) * f_values[x_pos, y_pos - 1] + beta * f_values[x_pos, y_pos])
+            - ((1 - beta) * f_values[x_pos - 1, y_pos - 1]
+               + beta * f_values[x_pos - 1, y_pos])) / (
+        x_grid[x_pos] - x_grid[x_pos - 1])
+    return dfdx
+
+
+# ============================================================
+# LinearInterpOnInterp1D — counterpart to HARK.interpolation.LinearInterpOnInterp1D
+# ============================================================
+
+def linear_interp_on_interp_1d_shared_xgrid(
+        x_grid, y_grid, f_values, x_query, y_query):
+    """
+    LinearInterpOnInterp1D when all inner 1-D interpolators share ``x_grid``.
+
+    Equivalent to bilinear interpolation with axes swapped (HARK's
+    LinearInterpOnInterp1D stores ``f_values`` with the y-axis first).
+
+    Parameters
+    ----------
+    x_grid : array_like, shape (Nx,)
+    y_grid : array_like, shape (Ny,)
+    f_values : array_like, shape (Ny, Nx)
+        ``f_values[k, j] = inner_interpolator_k(x_grid[j])``.
+    x_query, y_query : array_like
+        Query points, same shape.
+    """
+    return bilinear_interp(f_values.T, x_grid, y_grid, x_query, y_query)
+
+
+def linear_interp_on_interp_1d_general(
+        x_grids, y_grid, f_values, x_query, y_query):
+    """
+    LinearInterpOnInterp1D when each inner 1-D interpolator has its own
+    ``x_grid``.
+
+    Parameters
+    ----------
+    x_grids : array_like, shape (Ny, Nx)
+        Separate x-grid per y atom.
+    y_grid : array_like, shape (Ny,)
+        y values for each inner interpolator.
+    f_values : array_like, shape (Ny, Nx)
+        ``f_values[k, j] = inner_interpolator_k(x_grids[k, j])``.
+    x_query, y_query : array_like
+        Query points, same shape.
+
+    Notes
+    -----
+    Inner 1-D interpolations use ``lower_extrap=True`` to match HARK's
+    LinearInterpOnInterp1D, which calls the inner interpolators on raw queries.
+    """
+    x_grids = jnp.asarray(x_grids)
+    y_grid = jnp.asarray(y_grid)
+    f_values = jnp.asarray(f_values)
+    Ny = y_grid.shape[0]
+    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side='left'), 1, Ny - 1)
+    alpha = (y_query - y_grid[y_pos - 1]) / (y_grid[y_pos] - y_grid[y_pos - 1])
+
+    def per_query_lo(xq, idx):
+        return linear_interp_1d(x_grids[idx - 1], f_values[idx - 1], xq,
+                                lower_extrap=True)
+
+    def per_query_hi(xq, idx):
+        return linear_interp_1d(x_grids[idx], f_values[idx], xq,
+                                lower_extrap=True)
+
+    f_lo = jax.vmap(per_query_lo)(x_query, y_pos)
+    f_hi = jax.vmap(per_query_hi)(x_query, y_pos)
+    return (1 - alpha) * f_lo + alpha * f_hi
+
+
+# ============================================================
+# LowerEnvelope2D — counterpart to HARK.interpolation.LowerEnvelope2D
+# ============================================================
+
+def lower_envelope_2d_apply(*fvals):
+    """
+    Element-wise minimum across multiple function-value arrays, matching
+    ``HARK.interpolation.LowerEnvelope2D`` semantics.
+
+    Parameters
+    ----------
+    *fvals : tuple of array_like
+        Function values at common query points.
+
+    Returns
+    -------
+    array_like
+        Element-wise minimum, same shape as inputs.
+    """
+    out = fvals[0]
+    for f in fvals[1:]:
+        out = jnp.minimum(out, f)
+    return out
+
+
+# ============================================================
+# VariableLowerBoundFunc2D — counterpart to HARK.interpolation.VariableLowerBoundFunc2D
+# ============================================================
+
+def variable_lower_bound_eval(inner_fn, lb_values_at_y, x_query, y_query):
+    """
+    Evaluate ``inner_fn(x - lb(y), y)``.
+
+    Matches ``HARK.interpolation.VariableLowerBoundFunc2D`` when the caller
+    has pre-evaluated ``lb(y)`` at the query y values.
+
+    Parameters
+    ----------
+    inner_fn : callable
+        A function ``inner_fn(x, y) -> z`` that accepts JAX arrays.
+    lb_values_at_y : array_like
+        ``lb(y)`` evaluated at each ``y_query``.
+    x_query, y_query : array_like
+        Query points.
+    """
+    return inner_fn(x_query - lb_values_at_y, y_query)
+
+
+# ============================================================
+# CRRA marginal-utility helpers — counterpart to MargValueFuncCRRA
+# ============================================================
+
+def marg_value_to_consumption(vP, rho):
+    """
+    Invert CRRA marginal utility: return ``c`` such that ``u'(c) = vP``.
+
+    For CRRA utility, ``u'(c) = c^(-rho)``, so ``c = vP^(-1/rho)``.
+    """
+    return vP ** (-1.0 / rho)
+
+
+def consumption_to_marg_value(c, rho):
+    """
+    Forward CRRA marginal utility: ``u'(c) = c^(-rho)``.
+    """
+    return c ** (-rho)

--- a/HARK/interpolation_jax.py
+++ b/HARK/interpolation_jax.py
@@ -12,6 +12,7 @@ see ``HARK/tests/test_interpolation_jax.py`` for the parity tests.
 JAX is an optional dependency. Importing this module without JAX installed
 raises ``ImportError`` with installation instructions.
 """
+
 from __future__ import annotations
 
 try:
@@ -27,6 +28,7 @@ except ImportError as _e:  # pragma: no cover
 # ============================================================
 # 1-D linear interpolation — counterpart to HARK.interpolation.LinearInterp
 # ============================================================
+
 
 def linear_interp_1d(x_grid, y_vals, x_query, lower_extrap=False):
     """
@@ -59,7 +61,7 @@ def linear_interp_1d(x_grid, y_vals, x_query, lower_extrap=False):
     x_grid = jnp.asarray(x_grid)
     y_vals = jnp.asarray(y_vals)
     n = x_grid.shape[0]
-    i = jnp.clip(jnp.searchsorted(x_grid[:-1], x_query, side='left'), 1, n - 1)
+    i = jnp.clip(jnp.searchsorted(x_grid[:-1], x_query, side="left"), 1, n - 1)
     alpha = (x_query - x_grid[i - 1]) / (x_grid[i] - x_grid[i - 1])
     y = (1 - alpha) * y_vals[i - 1] + alpha * y_vals[i]
     if not lower_extrap:
@@ -70,6 +72,7 @@ def linear_interp_1d(x_grid, y_vals, x_query, lower_extrap=False):
 # ============================================================
 # 2-D bilinear interpolation — counterpart to HARK.interpolation.BilinearInterp
 # ============================================================
+
 
 def bilinear_interp(f_values, x_grid, y_grid, x_query, y_query):
     """
@@ -99,18 +102,20 @@ def bilinear_interp(f_values, x_grid, y_grid, x_query, y_query):
     y_grid = jnp.asarray(y_grid)
     Nx = x_grid.shape[0]
     Ny = y_grid.shape[0]
-    x_pos = jnp.clip(jnp.searchsorted(x_grid, x_query, side='left'), 1, Nx - 1)
-    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side='left'), 1, Ny - 1)
+    x_pos = jnp.clip(jnp.searchsorted(x_grid, x_query, side="left"), 1, Nx - 1)
+    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side="left"), 1, Ny - 1)
     alpha = (x_query - x_grid[x_pos - 1]) / (x_grid[x_pos] - x_grid[x_pos - 1])
     beta = (y_query - y_grid[y_pos - 1]) / (y_grid[y_pos] - y_grid[y_pos - 1])
     f00 = f_values[x_pos - 1, y_pos - 1]
     f01 = f_values[x_pos - 1, y_pos]
     f10 = f_values[x_pos, y_pos - 1]
     f11 = f_values[x_pos, y_pos]
-    return ((1 - alpha) * (1 - beta) * f00
-            + (1 - alpha) * beta * f01
-            + alpha * (1 - beta) * f10
-            + alpha * beta * f11)
+    return (
+        (1 - alpha) * (1 - beta) * f00
+        + (1 - alpha) * beta * f01
+        + alpha * (1 - beta) * f10
+        + alpha * beta * f11
+    )
 
 
 def bilinear_interp_derX(f_values, x_grid, y_grid, x_query, y_query):
@@ -125,13 +130,16 @@ def bilinear_interp_derX(f_values, x_grid, y_grid, x_query, y_query):
     y_grid = jnp.asarray(y_grid)
     Nx = x_grid.shape[0]
     Ny = y_grid.shape[0]
-    x_pos = jnp.clip(jnp.searchsorted(x_grid, x_query, side='left'), 1, Nx - 1)
-    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side='left'), 1, Ny - 1)
+    x_pos = jnp.clip(jnp.searchsorted(x_grid, x_query, side="left"), 1, Nx - 1)
+    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side="left"), 1, Ny - 1)
     beta = (y_query - y_grid[y_pos - 1]) / (y_grid[y_pos] - y_grid[y_pos - 1])
-    dfdx = (((1 - beta) * f_values[x_pos, y_pos - 1] + beta * f_values[x_pos, y_pos])
-            - ((1 - beta) * f_values[x_pos - 1, y_pos - 1]
-               + beta * f_values[x_pos - 1, y_pos])) / (
-        x_grid[x_pos] - x_grid[x_pos - 1])
+    dfdx = (
+        ((1 - beta) * f_values[x_pos, y_pos - 1] + beta * f_values[x_pos, y_pos])
+        - (
+            (1 - beta) * f_values[x_pos - 1, y_pos - 1]
+            + beta * f_values[x_pos - 1, y_pos]
+        )
+    ) / (x_grid[x_pos] - x_grid[x_pos - 1])
     return dfdx
 
 
@@ -139,8 +147,8 @@ def bilinear_interp_derX(f_values, x_grid, y_grid, x_query, y_query):
 # LinearInterpOnInterp1D — counterpart to HARK.interpolation.LinearInterpOnInterp1D
 # ============================================================
 
-def linear_interp_on_interp_1d_shared_xgrid(
-        x_grid, y_grid, f_values, x_query, y_query):
+
+def linear_interp_on_interp_1d_shared_xgrid(x_grid, y_grid, f_values, x_query, y_query):
     """
     LinearInterpOnInterp1D when all inner 1-D interpolators share ``x_grid``.
 
@@ -159,8 +167,7 @@ def linear_interp_on_interp_1d_shared_xgrid(
     return bilinear_interp(f_values.T, x_grid, y_grid, x_query, y_query)
 
 
-def linear_interp_on_interp_1d_general(
-        x_grids, y_grid, f_values, x_query, y_query):
+def linear_interp_on_interp_1d_general(x_grids, y_grid, f_values, x_query, y_query):
     """
     LinearInterpOnInterp1D when each inner 1-D interpolator has its own
     ``x_grid``.
@@ -185,16 +192,16 @@ def linear_interp_on_interp_1d_general(
     y_grid = jnp.asarray(y_grid)
     f_values = jnp.asarray(f_values)
     Ny = y_grid.shape[0]
-    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side='left'), 1, Ny - 1)
+    y_pos = jnp.clip(jnp.searchsorted(y_grid, y_query, side="left"), 1, Ny - 1)
     alpha = (y_query - y_grid[y_pos - 1]) / (y_grid[y_pos] - y_grid[y_pos - 1])
 
     def per_query_lo(xq, idx):
-        return linear_interp_1d(x_grids[idx - 1], f_values[idx - 1], xq,
-                                lower_extrap=True)
+        return linear_interp_1d(
+            x_grids[idx - 1], f_values[idx - 1], xq, lower_extrap=True
+        )
 
     def per_query_hi(xq, idx):
-        return linear_interp_1d(x_grids[idx], f_values[idx], xq,
-                                lower_extrap=True)
+        return linear_interp_1d(x_grids[idx], f_values[idx], xq, lower_extrap=True)
 
     f_lo = jax.vmap(per_query_lo)(x_query, y_pos)
     f_hi = jax.vmap(per_query_hi)(x_query, y_pos)
@@ -204,6 +211,7 @@ def linear_interp_on_interp_1d_general(
 # ============================================================
 # LowerEnvelope2D — counterpart to HARK.interpolation.LowerEnvelope2D
 # ============================================================
+
 
 def lower_envelope_2d_apply(*fvals):
     """
@@ -230,6 +238,7 @@ def lower_envelope_2d_apply(*fvals):
 # VariableLowerBoundFunc2D — counterpart to HARK.interpolation.VariableLowerBoundFunc2D
 # ============================================================
 
+
 def variable_lower_bound_eval(inner_fn, lb_values_at_y, x_query, y_query):
     """
     Evaluate ``inner_fn(x - lb(y), y)``.
@@ -252,6 +261,7 @@ def variable_lower_bound_eval(inner_fn, lb_values_at_y, x_query, y_query):
 # ============================================================
 # CRRA marginal-utility helpers — counterpart to MargValueFuncCRRA
 # ============================================================
+
 
 def marg_value_to_consumption(vP, rho):
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ Release Date: TBD
 
 #### Minor Changes
 
+- Adds `HARK.interpolation_jax`: opt-in JAX counterparts to core interpolation primitives (new module + tests only; no existing file's behavior changes). [#1777](https://github.com/econ-ark/HARK/pull/1777)
 - future item
 - future item
 - future item

--- a/tests/test_interpolation_jax.py
+++ b/tests/test_interpolation_jax.py
@@ -7,17 +7,20 @@ existing HARK implementation to a tight relative tolerance (1e-10 default).
 
 Skipped if JAX is not installed.
 """
+
 import os
 import unittest
 
 import numpy as np
 
 try:
-    os.environ.setdefault('JAX_ENABLE_X64', 'True')
+    os.environ.setdefault("JAX_ENABLE_X64", "True")
     import jax
-    jax.config.update('jax_enable_x64', True)
+
+    jax.config.update("jax_enable_x64", True)
     import jax.numpy as jnp
     from HARK import interpolation_jax as ij
+
     HAS_JAX = True
 except ImportError:
     HAS_JAX = False
@@ -61,12 +64,14 @@ class TestLinearInterp1DJax(unittest.TestCase):
         rng = np.random.default_rng(42)
         x_grid = np.sort(rng.uniform(0, 10, 20))
         y_vals = np.sin(x_grid) + 0.1 * x_grid
-        x_query = np.concatenate([
-            rng.uniform(x_grid.min(), x_grid.max(), 50),
-            np.array([x_grid.min() - 1.0, x_grid.min() - 0.001]),
-            np.array([x_grid.max() + 0.001, x_grid.max() + 5.0]),
-            x_grid,
-        ])
+        x_query = np.concatenate(
+            [
+                rng.uniform(x_grid.min(), x_grid.max(), 50),
+                np.array([x_grid.min() - 1.0, x_grid.min() - 0.001]),
+                np.array([x_grid.max() + 0.001, x_grid.max() + 5.0]),
+                x_grid,
+            ]
+        )
         hark = LinearInterp(x_grid, y_vals, lower_extrap=False)(x_query)
         jaxv = ij.linear_interp_1d(
             x_grid, y_vals, jnp.asarray(x_query), lower_extrap=False
@@ -93,14 +98,17 @@ class TestBilinearInterpJax(unittest.TestCase):
         rng = np.random.default_rng(44)
         x_grid = np.sort(rng.uniform(0, 10, 12))
         y_grid = np.sort(rng.uniform(0, 5, 8))
-        Xg, Yg = np.meshgrid(x_grid, y_grid, indexing='ij')
+        Xg, Yg = np.meshgrid(x_grid, y_grid, indexing="ij")
         f_vals = np.sin(Xg) * np.cos(Yg) + 0.1 * Xg
         x_query = rng.uniform(-1, 11, 80)
         y_query = rng.uniform(-0.5, 6, 80)
         hark = BilinearInterp(f_vals, x_grid, y_grid)(x_query, y_query)
         jaxv = ij.bilinear_interp(
-            f_vals, x_grid, y_grid,
-            jnp.asarray(x_query), jnp.asarray(y_query),
+            f_vals,
+            x_grid,
+            y_grid,
+            jnp.asarray(x_query),
+            jnp.asarray(y_query),
         )
         _assert_close(jaxv, hark, name="BilinearInterp value")
 
@@ -108,14 +116,17 @@ class TestBilinearInterpJax(unittest.TestCase):
         rng = np.random.default_rng(45)
         x_grid = np.sort(rng.uniform(0, 10, 10))
         y_grid = np.sort(rng.uniform(0, 5, 7))
-        Xg, Yg = np.meshgrid(x_grid, y_grid, indexing='ij')
-        f_vals = Xg ** 2 + Yg ** 2
+        Xg, Yg = np.meshgrid(x_grid, y_grid, indexing="ij")
+        f_vals = Xg**2 + Yg**2
         x_query = rng.uniform(1, 9, 50)
         y_query = rng.uniform(0.5, 4.5, 50)
         hark = BilinearInterp(f_vals, x_grid, y_grid).derivativeX(x_query, y_query)
         jaxv = ij.bilinear_interp_derX(
-            f_vals, x_grid, y_grid,
-            jnp.asarray(x_query), jnp.asarray(y_query),
+            f_vals,
+            x_grid,
+            y_grid,
+            jnp.asarray(x_query),
+            jnp.asarray(y_query),
         )
         _assert_close(jaxv, hark, name="BilinearInterp.derivativeX")
 
@@ -133,12 +144,17 @@ class TestLinearInterpOnInterp1DJax(unittest.TestCase):
             f_vals[k] = np.sin(x_grid) + 0.3 * y * x_grid
         x_query = rng.uniform(x_grid.min(), x_grid.max(), 40)
         y_query = rng.uniform(y_grid.min(), y_grid.max(), 40)
-        inner = [LinearInterp(x_grid, f_vals[k], lower_extrap=True)
-                 for k in range(len(y_grid))]
+        inner = [
+            LinearInterp(x_grid, f_vals[k], lower_extrap=True)
+            for k in range(len(y_grid))
+        ]
         hark = LinearInterpOnInterp1D(inner, y_grid)(x_query, y_query)
         jaxv = ij.linear_interp_on_interp_1d_shared_xgrid(
-            x_grid, y_grid, f_vals,
-            jnp.asarray(x_query), jnp.asarray(y_query),
+            x_grid,
+            y_grid,
+            f_vals,
+            jnp.asarray(x_query),
+            jnp.asarray(y_query),
         )
         _assert_close(jaxv, hark, name="LinearInterpOnInterp1D shared x_grid")
 
@@ -153,12 +169,17 @@ class TestLinearInterpOnInterp1DJax(unittest.TestCase):
             f_vals[k] = np.sin(x_grids[k]) + 0.3 * y * x_grids[k]
         x_query = rng.uniform(2, 8, 30)
         y_query = rng.uniform(y_grid.min(), y_grid.max(), 30)
-        inner = [LinearInterp(x_grids[k], f_vals[k], lower_extrap=True)
-                 for k in range(len(y_grid))]
+        inner = [
+            LinearInterp(x_grids[k], f_vals[k], lower_extrap=True)
+            for k in range(len(y_grid))
+        ]
         hark = LinearInterpOnInterp1D(inner, y_grid)(x_query, y_query)
         jaxv = ij.linear_interp_on_interp_1d_general(
-            x_grids, y_grid, f_vals,
-            jnp.asarray(x_query), jnp.asarray(y_query),
+            x_grids,
+            y_grid,
+            f_vals,
+            jnp.asarray(x_query),
+            jnp.asarray(y_query),
         )
         _assert_close(jaxv, hark, name="LinearInterpOnInterp1D per-y x_grid")
 
@@ -193,5 +214,5 @@ class TestCRRAHelpersJax(unittest.TestCase):
         _assert_close(c_back, c, name="CRRA inverse u'^-1")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_interpolation_jax.py
+++ b/tests/test_interpolation_jax.py
@@ -1,0 +1,197 @@
+"""
+Bit-precision parity tests for ``HARK.interpolation_jax`` vs the numpy/numba
+implementations in ``HARK.interpolation``.
+
+Each test uses fixed-seed random inputs and asserts the JAX result matches the
+existing HARK implementation to a tight relative tolerance (1e-10 default).
+
+Skipped if JAX is not installed.
+"""
+import os
+import unittest
+
+import numpy as np
+
+try:
+    os.environ.setdefault('JAX_ENABLE_X64', 'True')
+    import jax
+    jax.config.update('jax_enable_x64', True)
+    import jax.numpy as jnp
+    from HARK import interpolation_jax as ij
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
+
+from HARK.interpolation import (
+    LinearInterp,
+    BilinearInterp,
+    LinearInterpOnInterp1D,
+)
+
+
+PRECISION = 1e-10
+
+
+def _assert_close(jax_val, hark_val, tol=PRECISION, name=""):
+    jax_val = np.asarray(jax_val)
+    hark_val = np.asarray(hark_val)
+    finite_match = np.isfinite(jax_val) == np.isfinite(hark_val)
+    assert finite_match.all(), (
+        f"{name}: NaN pattern mismatch — "
+        f"JAX has {(~np.isfinite(jax_val)).sum()} NaNs, "
+        f"HARK has {(~np.isfinite(hark_val)).sum()} NaNs"
+    )
+    finite = np.isfinite(jax_val)
+    if not finite.any():
+        return
+    rel = np.abs(
+        (jax_val[finite] - hark_val[finite])
+        / np.maximum(np.abs(hark_val[finite]), 1e-15)
+    )
+    assert rel.max() < tol, (
+        f"{name}: max relative diff = {rel.max():.2e} (> tol {tol:.0e})"
+    )
+
+
+@unittest.skipUnless(HAS_JAX, "JAX not installed")
+class TestLinearInterp1DJax(unittest.TestCase):
+    """``linear_interp_1d`` vs ``HARK.interpolation.LinearInterp``."""
+
+    def test_no_lower_extrap(self):
+        rng = np.random.default_rng(42)
+        x_grid = np.sort(rng.uniform(0, 10, 20))
+        y_vals = np.sin(x_grid) + 0.1 * x_grid
+        x_query = np.concatenate([
+            rng.uniform(x_grid.min(), x_grid.max(), 50),
+            np.array([x_grid.min() - 1.0, x_grid.min() - 0.001]),
+            np.array([x_grid.max() + 0.001, x_grid.max() + 5.0]),
+            x_grid,
+        ])
+        hark = LinearInterp(x_grid, y_vals, lower_extrap=False)(x_query)
+        jaxv = ij.linear_interp_1d(
+            x_grid, y_vals, jnp.asarray(x_query), lower_extrap=False
+        )
+        _assert_close(jaxv, hark, name="LinearInterp no decay extrap")
+
+    def test_lower_extrap(self):
+        rng = np.random.default_rng(43)
+        x_grid = np.sort(rng.uniform(0, 10, 15))
+        y_vals = np.exp(-x_grid)
+        x_query = rng.uniform(-5, 15, 100)
+        hark = LinearInterp(x_grid, y_vals, lower_extrap=True)(x_query)
+        jaxv = ij.linear_interp_1d(
+            x_grid, y_vals, jnp.asarray(x_query), lower_extrap=True
+        )
+        _assert_close(jaxv, hark, name="LinearInterp lower_extrap")
+
+
+@unittest.skipUnless(HAS_JAX, "JAX not installed")
+class TestBilinearInterpJax(unittest.TestCase):
+    """``bilinear_interp`` and ``bilinear_interp_derX`` vs ``BilinearInterp``."""
+
+    def test_value(self):
+        rng = np.random.default_rng(44)
+        x_grid = np.sort(rng.uniform(0, 10, 12))
+        y_grid = np.sort(rng.uniform(0, 5, 8))
+        Xg, Yg = np.meshgrid(x_grid, y_grid, indexing='ij')
+        f_vals = np.sin(Xg) * np.cos(Yg) + 0.1 * Xg
+        x_query = rng.uniform(-1, 11, 80)
+        y_query = rng.uniform(-0.5, 6, 80)
+        hark = BilinearInterp(f_vals, x_grid, y_grid)(x_query, y_query)
+        jaxv = ij.bilinear_interp(
+            f_vals, x_grid, y_grid,
+            jnp.asarray(x_query), jnp.asarray(y_query),
+        )
+        _assert_close(jaxv, hark, name="BilinearInterp value")
+
+    def test_derivativeX(self):
+        rng = np.random.default_rng(45)
+        x_grid = np.sort(rng.uniform(0, 10, 10))
+        y_grid = np.sort(rng.uniform(0, 5, 7))
+        Xg, Yg = np.meshgrid(x_grid, y_grid, indexing='ij')
+        f_vals = Xg ** 2 + Yg ** 2
+        x_query = rng.uniform(1, 9, 50)
+        y_query = rng.uniform(0.5, 4.5, 50)
+        hark = BilinearInterp(f_vals, x_grid, y_grid).derivativeX(x_query, y_query)
+        jaxv = ij.bilinear_interp_derX(
+            f_vals, x_grid, y_grid,
+            jnp.asarray(x_query), jnp.asarray(y_query),
+        )
+        _assert_close(jaxv, hark, name="BilinearInterp.derivativeX")
+
+
+@unittest.skipUnless(HAS_JAX, "JAX not installed")
+class TestLinearInterpOnInterp1DJax(unittest.TestCase):
+    """``linear_interp_on_interp_1d_*`` vs ``LinearInterpOnInterp1D``."""
+
+    def test_shared_xgrid(self):
+        rng = np.random.default_rng(46)
+        x_grid = np.sort(rng.uniform(0, 10, 15))
+        y_grid = np.sort(rng.uniform(0, 5, 4))
+        f_vals = np.zeros((len(y_grid), len(x_grid)))
+        for k, y in enumerate(y_grid):
+            f_vals[k] = np.sin(x_grid) + 0.3 * y * x_grid
+        x_query = rng.uniform(x_grid.min(), x_grid.max(), 40)
+        y_query = rng.uniform(y_grid.min(), y_grid.max(), 40)
+        inner = [LinearInterp(x_grid, f_vals[k], lower_extrap=True)
+                 for k in range(len(y_grid))]
+        hark = LinearInterpOnInterp1D(inner, y_grid)(x_query, y_query)
+        jaxv = ij.linear_interp_on_interp_1d_shared_xgrid(
+            x_grid, y_grid, f_vals,
+            jnp.asarray(x_query), jnp.asarray(y_query),
+        )
+        _assert_close(jaxv, hark, name="LinearInterpOnInterp1D shared x_grid")
+
+    def test_per_y_xgrid(self):
+        rng = np.random.default_rng(47)
+        y_grid = np.sort(rng.uniform(0, 5, 4))
+        Nx = 12
+        x_grids = np.zeros((len(y_grid), Nx))
+        f_vals = np.zeros((len(y_grid), Nx))
+        for k, y in enumerate(y_grid):
+            x_grids[k] = np.sort(rng.uniform(0, 10, Nx))
+            f_vals[k] = np.sin(x_grids[k]) + 0.3 * y * x_grids[k]
+        x_query = rng.uniform(2, 8, 30)
+        y_query = rng.uniform(y_grid.min(), y_grid.max(), 30)
+        inner = [LinearInterp(x_grids[k], f_vals[k], lower_extrap=True)
+                 for k in range(len(y_grid))]
+        hark = LinearInterpOnInterp1D(inner, y_grid)(x_query, y_query)
+        jaxv = ij.linear_interp_on_interp_1d_general(
+            x_grids, y_grid, f_vals,
+            jnp.asarray(x_query), jnp.asarray(y_query),
+        )
+        _assert_close(jaxv, hark, name="LinearInterpOnInterp1D per-y x_grid")
+
+
+@unittest.skipUnless(HAS_JAX, "JAX not installed")
+class TestLowerEnvelope2DJax(unittest.TestCase):
+    """``lower_envelope_2d_apply`` vs element-wise numpy minimum."""
+
+    def test_element_wise_min(self):
+        rng = np.random.default_rng(48)
+        N = 50
+        f1 = rng.uniform(0, 10, N)
+        f2 = rng.uniform(0, 10, N)
+        f3 = rng.uniform(0, 10, N)
+        jaxv = ij.lower_envelope_2d_apply(
+            jnp.asarray(f1), jnp.asarray(f2), jnp.asarray(f3)
+        )
+        expected = np.minimum(np.minimum(f1, f2), f3)
+        _assert_close(jaxv, expected, name="LowerEnvelope2D min")
+
+
+@unittest.skipUnless(HAS_JAX, "JAX not installed")
+class TestCRRAHelpersJax(unittest.TestCase):
+    """``marg_value_to_consumption`` round-trip via ``consumption_to_marg_value``."""
+
+    def test_inverse_roundtrip(self):
+        rng = np.random.default_rng(49)
+        rho = 2.0
+        c = rng.uniform(0.1, 5.0, 30)
+        vP = c ** (-rho)
+        c_back = ij.marg_value_to_consumption(jnp.asarray(vP), rho)
+        _assert_close(c_back, c, name="CRRA inverse u'^-1")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_interpolation_jax.py
+++ b/tests/test_interpolation_jax.py
@@ -214,5 +214,154 @@ class TestCRRAHelpersJax(unittest.TestCase):
         _assert_close(c_back, c, name="CRRA inverse u'^-1")
 
 
+# ============================================================
+# Edge-case coverage (broader matrix follow-up)
+# ============================================================
+
+
+@unittest.skipUnless(HAS_JAX, "JAX not installed")
+class TestLinearInterp1DEdgeCases(unittest.TestCase):
+    """Edge cases for ``linear_interp_1d`` parity."""
+
+    def test_two_point_grid(self):
+        """Minimum-size grid (n=2): everything is the single segment."""
+        x_grid = np.array([0.0, 1.0])
+        y_vals = np.array([3.0, 5.0])
+        x_query = np.array([-0.5, 0.0, 0.25, 0.5, 1.0, 1.5])
+        hark = LinearInterp(x_grid, y_vals, lower_extrap=True)(x_query)
+        jaxv = ij.linear_interp_1d(
+            x_grid, y_vals, jnp.asarray(x_query), lower_extrap=True
+        )
+        _assert_close(jaxv, hark, name="LinearInterp n=2 grid")
+
+    def test_constant_function(self):
+        """All y_vals equal: result must be constant."""
+        x_grid = np.linspace(0, 10, 30)
+        y_vals = np.full(30, 7.42)
+        x_query = np.linspace(-5, 15, 50)
+        hark = LinearInterp(x_grid, y_vals, lower_extrap=True)(x_query)
+        jaxv = ij.linear_interp_1d(
+            x_grid, y_vals, jnp.asarray(x_query), lower_extrap=True
+        )
+        _assert_close(jaxv, hark, name="LinearInterp constant y")
+
+    def test_single_query(self):
+        """Scalar query (shape ()): result should also be scalar."""
+        rng = np.random.default_rng(101)
+        x_grid = np.sort(rng.uniform(0, 10, 20))
+        y_vals = np.sin(x_grid)
+        for x_q in (0.001, 5.0, 9.999):
+            hark = float(LinearInterp(x_grid, y_vals, lower_extrap=True)(x_q))
+            jaxv = float(
+                ij.linear_interp_1d(x_grid, y_vals, jnp.asarray(x_q), lower_extrap=True)
+            )
+            self.assertAlmostEqual(jaxv, hark, places=8, msg=f"scalar query x={x_q}")
+
+    def test_large_query_array(self):
+        """1e5 query points — vectorization correctness, not timing."""
+        rng = np.random.default_rng(102)
+        x_grid = np.sort(rng.uniform(0, 100, 50))
+        y_vals = np.cos(x_grid)
+        x_query = rng.uniform(0, 100, 100_000)
+        hark = LinearInterp(x_grid, y_vals, lower_extrap=True)(x_query)
+        jaxv = ij.linear_interp_1d(
+            x_grid, y_vals, jnp.asarray(x_query), lower_extrap=True
+        )
+        _assert_close(jaxv, hark, name="LinearInterp 100k queries")
+
+    def test_strictly_decreasing_values_increasing_grid(self):
+        """Monotone-decreasing y on monotone-increasing x grid."""
+        x_grid = np.linspace(0.1, 10, 25)
+        y_vals = 1.0 / x_grid  # strictly decreasing
+        x_query = np.linspace(0.5, 9.5, 50)
+        hark = LinearInterp(x_grid, y_vals, lower_extrap=True)(x_query)
+        jaxv = ij.linear_interp_1d(
+            x_grid, y_vals, jnp.asarray(x_query), lower_extrap=True
+        )
+        _assert_close(jaxv, hark, name="LinearInterp 1/x decreasing y")
+
+
+@unittest.skipUnless(HAS_JAX, "JAX not installed")
+class TestBilinearInterpEdgeCases(unittest.TestCase):
+    """Edge cases for ``bilinear_interp`` parity."""
+
+    def test_two_by_two_grid(self):
+        """Minimum-size 2D grid: a single bilinear patch."""
+        x_grid = np.array([0.0, 1.0])
+        y_grid = np.array([0.0, 1.0])
+        f_vals = np.array([[1.0, 2.0], [3.0, 5.0]])  # bilinear in x and y
+        x_query = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        y_query = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        hark = BilinearInterp(f_vals, x_grid, y_grid)(x_query, y_query)
+        jaxv = ij.bilinear_interp(
+            f_vals,
+            x_grid,
+            y_grid,
+            jnp.asarray(x_query),
+            jnp.asarray(y_query),
+        )
+        _assert_close(jaxv, hark, name="BilinearInterp 2x2 grid")
+
+    def test_constant_2d(self):
+        """f_vals all equal: bilinear result must be the constant."""
+        x_grid = np.linspace(0, 10, 8)
+        y_grid = np.linspace(0, 5, 6)
+        f_vals = np.full((8, 6), -3.14)
+        rng = np.random.default_rng(103)
+        x_query = rng.uniform(-1, 11, 25)
+        y_query = rng.uniform(-1, 6, 25)
+        hark = BilinearInterp(f_vals, x_grid, y_grid)(x_query, y_query)
+        jaxv = ij.bilinear_interp(
+            f_vals,
+            x_grid,
+            y_grid,
+            jnp.asarray(x_query),
+            jnp.asarray(y_query),
+        )
+        _assert_close(jaxv, hark, name="BilinearInterp constant 2D")
+
+    def test_exact_grid_points(self):
+        """Queries at exact grid corners must return the corner values."""
+        rng = np.random.default_rng(104)
+        x_grid = np.sort(rng.uniform(0, 10, 8))
+        y_grid = np.sort(rng.uniform(0, 5, 6))
+        f_vals = rng.uniform(-2, 2, (8, 6))
+        Xg, Yg = np.meshgrid(x_grid, y_grid, indexing="ij")
+        x_query = Xg.flatten()
+        y_query = Yg.flatten()
+        hark = BilinearInterp(f_vals, x_grid, y_grid)(x_query, y_query)
+        jaxv = ij.bilinear_interp(
+            f_vals,
+            x_grid,
+            y_grid,
+            jnp.asarray(x_query),
+            jnp.asarray(y_query),
+        )
+        _assert_close(jaxv, hark, name="BilinearInterp exact corners")
+
+
+@unittest.skipUnless(HAS_JAX, "JAX not installed")
+class TestCRRAHelpersEdgeCases(unittest.TestCase):
+    """Edge cases for CRRA helpers."""
+
+    def test_log_utility_rho_1(self):
+        """CRRA=1 (log utility) round-trip."""
+        rng = np.random.default_rng(105)
+        rho = 1.0
+        c = rng.uniform(0.1, 5.0, 30)
+        vP = c ** (-rho)
+        c_back = ij.marg_value_to_consumption(jnp.asarray(vP), rho)
+        _assert_close(c_back, c, name="CRRA rho=1 (log)")
+
+    def test_high_curvature_rho_6(self):
+        """High curvature rho=6 round-trip — vP can be very large for small c."""
+        rng = np.random.default_rng(106)
+        rho = 6.0
+        c = rng.uniform(0.5, 5.0, 30)  # avoid c→0 where vP→inf
+        vP = c ** (-rho)
+        c_back = ij.marg_value_to_consumption(jnp.asarray(vP), rho)
+        _assert_close(c_back, c, name="CRRA rho=6 (high curvature)")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> ⚠️ **CI note:** the one failing job, `build (ubuntu-latest, 3.12)`, is a **pre-existing breakage on unmodified `main`** — scipy 1.18.0's spline objects cannot be `deepcopy`-ed, which detonates in the existing test suite wherever that scipy resolves. Root cause, three-line repro, and the one-line fix: **#1788** (merge that first). Every other job here is green; once #1788 merges I will refresh this branch so the matrix shows fully green.

> **Non-disruption note (2026-08-10):** this PR adds a new module and its tests only — no existing code file's behavior changes (a changelog entry is the sole edit to an existing file). Now marked ready for review as part of a short series of self-contained upstreaming PRs (see also #1783, #1784).
>
> - [x] Tests added for new functionality (18 cases)
> - [x] Documented (numpydoc docstrings)
> - [x] CHANGELOG.md updated

## Summary

Adds a new opt-in module, `HARK.interpolation_jax`, that ports the interpolation primitives used by `ConsAggShockModel`-style solvers to JAX. The new module is functional (data + query arguments, no classes) so the functions can be `vmap`-ed, `jit`-ed, and differentiated — the building blocks needed for a GPU EGM solver in a follow-up PR.

## Why

HAFiscal (Carroll et al.) has a working JAX EGM solver kernel for HARK's `solve_agg_cons_markov_alt` that validates to <1e-3 vs HARK at recession scale. The interpolation primitives in that kernel have lived as `HAFiscal/jax_hark_interp.py`. This PR upstreams them in HARK-quality shape so any downstream project can reuse them.

Sets the foundation for:
- **PR-2**: `ConsIndShockModelJAX` — JAX EGM for the basic single-state consumer
- **PR-3**: `ConsAggShockModelJAX` — JAX EGM for the Markov + aggregate-state variant (matches HAFiscal's solver structure)

## What this PR adds

New module **`HARK/interpolation_jax.py`** (192 lines) — JAX counterparts to:

| JAX function | HARK reference |
|---|---|
| ` linear_interp_1d ` | `LinearInterp` |
| ` bilinear_interp ` | `BilinearInterp` |
| ` bilinear_interp_derX ` | `BilinearInterp.derivativeX` |
| ` linear_interp_on_interp_1d_shared_xgrid ` | `LinearInterpOnInterp1D` (shared x) |
| ` linear_interp_on_interp_1d_general ` | `LinearInterpOnInterp1D` (per-y x) |
| ` lower_envelope_2d_apply ` | `LowerEnvelope2D` |
| ` variable_lower_bound_eval ` | `VariableLowerBoundFunc2D` |
| ` marg_value_to_consumption ` / ` consumption_to_marg_value ` | `MargValueFuncCRRA` helpers |

New test module **`tests/test_interpolation_jax.py`** (8 tests) — bit-precision parity at 1e-10 relative tolerance against the existing numpy/numba implementations. Tests skip cleanly when JAX is not installed.

## What this PR is NOT

- **Not** a change to any existing module — no behavior change for users who don't import the new module.
- **Not** a new core dependency — JAX is optional, gated by a try/except import guard with a helpful install message.
- **Not** a solver — solver lives in PR-2 / PR-3.

## Test results (local)

\`\`\`
tests/test_interpolation_jax.py::TestLinearInterp1DJax::test_lower_extrap PASSED
tests/test_interpolation_jax.py::TestLinearInterp1DJax::test_no_lower_extrap PASSED
tests/test_interpolation_jax.py::TestBilinearInterpJax::test_derivativeX PASSED
tests/test_interpolation_jax.py::TestBilinearInterpJax::test_value PASSED
tests/test_interpolation_jax.py::TestLinearInterpOnInterp1DJax::test_per_y_xgrid PASSED
tests/test_interpolation_jax.py::TestLinearInterpOnInterp1DJax::test_shared_xgrid PASSED
tests/test_interpolation_jax.py::TestLowerEnvelope2DJax::test_element_wise_min PASSED
tests/test_interpolation_jax.py::TestCRRAHelpersJax::test_inverse_roundtrip PASSED
============================== 8 passed in 4.72s ===============================
\`\`\`

## Risk

Zero. The module adds new files; no existing imports change. Users who don't `import HARK.interpolation_jax` see no difference.

## Notes for the reviewer

- **API choice** — functional vs class-based. Chose functional to keep `vmap`/`jit` mechanical; a class-wrapper layer can be added in PR-2/PR-3 if HARK's solver API requires it.
- **Search semantics** — `linear_interp_1d` deliberately mirrors HARK's `searchsorted(x_grid[:-1], ...)` quirk so above-top queries linearly extrapolate from the last segment rather than NaN. Documented inline.
- **`derivativeX` only** — `BilinearInterp` also exposes `derivativeY`; not ported here because the HAFiscal solver doesn't use it. Trivial to add in a follow-up if anyone needs it.

## Test plan

- [x] All 8 parity tests pass at 1e-10 (local, Python 3.11, JAX 0.4.x)
- [ ] CI parity tests pass (will surface in PR checks)
- [ ] Tests skip cleanly on CI image without JAX (will surface in PR checks)

