### PR TITLE
Docs: add the missing API reference page for ConsAggIndMarkovModel

### DIFF
--- a/docs/reference/ConsumptionSaving/ConsAggIndMarkovModel.rst
+++ b/docs/reference/ConsumptionSaving/ConsAggIndMarkovModel.rst
@@ -1,0 +1,7 @@
+ConsAggIndMarkovModel
+---------------------
+
+.. automodule:: HARK.ConsumptionSaving.ConsAggIndMarkovModel
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -24,6 +24,7 @@ API Reference
    :caption: Models
    :maxdepth: 1
 
+   ConsumptionSaving/ConsAggIndMarkovModel
    ConsumptionSaving/ConsAggShockModel
    ConsumptionSaving/ConsBequestModel
    ConsumptionSaving/ConsGenIncProcessModel


### PR DESCRIPTION
Documentation-only PR: `HARK.ConsumptionSaving.ConsAggIndMarkovModel` ships in the library but has no rendered page on docs.econ-ark.org. This adds the standard `automodule` stub (members, undoc-members, show-inheritance — the same shape as the neighboring model pages) and its toctree entry in the API reference index.

No code is touched; the Render CI job is the relevant check.

- [x] Documentation updated (that is the entire PR)
