### PR TITLE
Exclude scipy 1.18.0: its spline objects cannot be deepcopy-ed (fixes the failing py3.12 CI job)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ Release Date: TBD
 
 #### Minor Changes
 
+- Excludes scipy 1.18.0, whose `PPoly`-family objects (e.g. `CubicHermiteSpline`) cannot be `deepcopy`-ed (`TypeError: cannot pickle 'module' object`), breaking `ValueFuncCRRA` construction and the existing test suite wherever that scipy version is resolved. [#1788](https://github.com/econ-ark/HARK/pull/1788)
 - future item
 - future item
 - future item

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ optimagic
 pandas>=1.5
 pyyaml>=6.0
 quantecon
-scipy>=1.10
+scipy>=1.10,!=1.18.0
 seaborn>=0.12
 sequence-jacobian
 statsmodels>=0.14.2


### PR DESCRIPTION
scipy 1.18.0's `PPoly`-family objects (`CubicHermiteSpline` et al.) raise `TypeError: cannot pickle 'module' object` under `copy.deepcopy`. HARK's `ValueFuncCRRA` deepcopies the interpolant it wraps, so any environment that resolves scipy 1.18.0 — currently the `build (ubuntu-latest, 3.12)` CI job — fails almost immediately in the **existing** test suite. Reproduced on unmodified `main`; minimal repro:

```python
from scipy.interpolate import CubicHermiteSpline
import copy, numpy as np
s = CubicHermiteSpline(np.arange(3.), np.arange(3.)**2, 2*np.arange(3.))
copy.deepcopy(s)   # TypeError on 1.18.0; fine on 1.17.x
```

With `scipy<1.18` the full pre-existing `tests/ConsumptionSaving/test_IndShockConsumerType.py` passes on py3.12 (22 passed). The pin is spelled `!=1.18.0` so a fixed 1.18.1 will be picked up automatically. (A HARK-side hardening — e.g. a `__deepcopy__` on `CubicHermiteInterp` that reconstructs rather than pickles — could follow separately; this unblocks CI now. Worth reporting upstream to scipy as well.)

This is why the `ubuntu-3.12` job currently fails on every open PR that runs the build matrix — including the unmodified-code series #1777/#1783/#1784/#1786/#1787. Merging this first turns those matrices fully green.

- [x] CHANGELOG.md updated