### PR TITLE
Fix the pre-commit failure on main (stray blank line)

### DIFF
--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -957,7 +957,6 @@ class CalcExpectationDeprecatedAlias(unittest.TestCase):
     alias that delegates exactly to expected_with_loop."""
 
     def test_alias_delegates_and_warns(self):
-
         dd = DiscreteDistribution(np.array([0.25, 0.75]), np.array([2.0, 4.0]), seed=0)
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")


### PR DESCRIPTION
`main` has been failing the `pre-commit` job since c1c6d262, which puts every open PR into a BLOCKED merge state.

```
1 file reformatted, 211 files left unchanged
pre-commit hook(s) made changes.
```

The change ruff format wants is a single blank line in `tests/test_distribution.py`, immediately after `def test_alias_delegates_and_warns(self):`. It came in when that test's imports were hoisted to module scope during the #1800 review, and the merge went in before the job reported.

Verified locally: `ruff format --check tests/test_distribution.py` reports "1 file already formatted", and the test itself still passes.