### PR TITLE
Make numba optional so HARK imports in the browser (#1806)

### DIFF
--- a/.github/workflows/hark.yml
+++ b/.github/workflows/hark.yml
@@ -70,3 +70,32 @@ jobs:
       - name: Test with pytest
         run: |
           pytest -n auto
+
+  # With numba installed, CI never executes the HARK._numba fallback, so a
+  # divergence in the pure-Python path would reach a browser user unseen.
+  # Removing numba plus the two packages requiring it gives the wasm dep set.
+  no-numba:
+    name: Test with numba absent (browser install)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install without numba
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[dev]"
+          pip uninstall -y numba interpolation quantecon
+      - name: Confirm numba is genuinely absent
+        run: |
+          if python -c "import numba" 2>/dev/null; then
+            echo "numba still importable; this job would pass for the wrong reason"
+            exit 1
+          fi
+      - name: Test with pytest
+        run: |
+          pytest -n auto --ignore=tests/test_dcegm.py \
+                         --ignore=tests/test_econforgeinterp.py \
+                         --ignore=tests/ConsumptionSaving/test_IndShockConsumerTypeFast.py \
+                         --ignore=tests/ConsumptionSaving/test_PerfForesightFastConsumerType.py

--- a/HARK/ConsumptionSaving/ConsIndShockModelFast.py
+++ b/HARK/ConsumptionSaving/ConsIndShockModelFast.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 
 import numpy as np
 from interpolation import interp
-from numba import njit
+from HARK._numba import njit
 from quantecon.optimize import newton_secant
 
 from HARK import make_one_period_oo_solver

--- a/HARK/ConsumptionSaving/__init__.py
+++ b/HARK/ConsumptionSaving/__init__.py
@@ -85,8 +85,11 @@ try:
     )
 except ImportError as _fast_exc:  # pragma: no cover - only where numba is absent
     # The Fast variants need third-party `interpolation` and `quantecon`, which
-    # import numba themselves, so HARK._numba cannot cover them. Keep the names
-    # bound so `import HARK.ConsumptionSaving` still works, and explain on use.
+    # import numba themselves, so HARK._numba cannot cover them. Narrow by module
+    # name so a bug inside the Fast module is never reported as a missing dep.
+    if _fast_exc.name not in ("numba", "interpolation", "quantecon"):
+        raise
+
     def _fast_unavailable(*args, **kwargs):
         raise ImportError(
             "The Fast consumer types require the 'interpolation' and 'quantecon' "

--- a/HARK/ConsumptionSaving/__init__.py
+++ b/HARK/ConsumptionSaving/__init__.py
@@ -77,10 +77,26 @@ from HARK.ConsumptionSaving.ConsWealthPortfolioModel import WealthPortfolioConsu
 from HARK.ConsumptionSaving.ConsLaborModel import LaborIntMargConsumerType
 from HARK.ConsumptionSaving.ConsHealthModel import BasicHealthConsumerType
 from HARK.ConsumptionSaving.ConsRiskyContribModel import RiskyContribConsumerType
-from HARK.ConsumptionSaving.ConsIndShockModelFast import (
-    IndShockConsumerTypeFast,
-    PerfForesightConsumerTypeFast,
-)
+
+try:
+    from HARK.ConsumptionSaving.ConsIndShockModelFast import (
+        IndShockConsumerTypeFast,
+        PerfForesightConsumerTypeFast,
+    )
+except ImportError as _fast_exc:  # pragma: no cover - only where numba is absent
+    # The Fast variants need third-party `interpolation` and `quantecon`, which
+    # import numba themselves, so HARK._numba cannot cover them. Keep the names
+    # bound so `import HARK.ConsumptionSaving` still works, and explain on use.
+    def _fast_unavailable(*args, **kwargs):
+        raise ImportError(
+            "The Fast consumer types require the 'interpolation' and 'quantecon' "
+            "packages, which import numba. numba is unavailable on this platform "
+            "(for example stock Pyodide), so use IndShockConsumerType or "
+            "PerfForesightConsumerType instead."
+        ) from _fast_exc
+
+    IndShockConsumerTypeFast = _fast_unavailable
+    PerfForesightConsumerTypeFast = _fast_unavailable
 from HARK.ConsumptionSaving.ConsHabitModel import (
     HabitConsumerType,
     HabitPortfolioConsumerType,

--- a/HARK/SSJutils.py
+++ b/HARK/SSJutils.py
@@ -7,7 +7,7 @@ AgentType itself.
 from time import time
 from copy import deepcopy
 import numpy as np
-from numba import njit
+from HARK._numba import njit
 
 
 def _prepare_ssj_computation(agent, outcomes, grids, norm, solved, verbose):

--- a/HARK/_numba.py
+++ b/HARK/_numba.py
@@ -1,0 +1,53 @@
+"""Optional numba, so that HARK imports on targets where numba has no build.
+
+``HARK.core`` reaches ``numba`` through ``HARK.simulator``, ``HARK.SSJutils`` and
+``HARK.utilities``, so without this module ``import HARK`` fails outright wherever
+numba is missing. That is the situation on stock Pyodide and PyScript, whose package
+set has neither ``numba`` nor ``llvmlite``, and it is also what a minimal install
+without the compiled stack looks like.
+
+Where numba is present, including JupyterLite with the emscripten-forge xeus-python
+kernel, the real ``njit`` and ``prange`` are re-exported and behaviour is unchanged.
+
+The fallback ``njit`` has to cover every calling convention HARK uses, because numba
+spells three different things with one name:
+
+    @njit                                       bare decorator
+    @njit(cache=True)                           decorator factory
+    @njit(parallel=True)                        decorator factory
+    @njit("float64(float64[:])", cache=True)    factory with a signature string
+    CRRAutility = njit(CRRAutility_X, cache=True)   direct call on a function
+
+The last form is the dangerous one and it is live in ``HARK.numba_tools``. A guard
+that only returns the function for a callable first argument *without* keywords will
+hand back a decorator instead, so ``CRRAutility(c, rho)`` silently returns ``c``
+rather than raising. The test is therefore whether the first argument is callable,
+independent of the keywords. A signature string is not callable, so that form still
+reaches the factory branch, which is what it needs.
+
+``prange`` falls back to ``range``. numba's ``prange`` is ``range`` plus a
+parallelism hint, and the loops HARK uses it in are order independent, so serial
+execution is correct and only slower.
+"""
+
+from __future__ import annotations
+
+try:
+    from numba import njit, prange
+
+    HAS_NUMBA = True
+except ImportError:  # pragma: no cover - exercised only where numba is absent
+    HAS_NUMBA = False
+
+    prange = range
+
+    def njit(*args, **kwargs):
+        """No-op stand-in for ``numba.njit`` that runs the pure-Python function."""
+        if args and callable(args[0]):
+            # @njit, njit(func), and njit(func, cache=True)
+            return args[0]
+        # @njit(...), including a leading signature string
+        return lambda func: func
+
+
+__all__ = ["HAS_NUMBA", "njit", "prange"]

--- a/HARK/dcegm.py
+++ b/HARK/dcegm.py
@@ -9,7 +9,7 @@ Example can be found in https://github.com/econ-ark/DemARK/blob/master/notebooks
 
 import numpy as np
 from interpolation import interp
-from numba import njit
+from HARK._numba import njit
 
 
 @njit("Tuple((float64,float64))(float64[:], float64[:], float64[:])", cache=True)

--- a/HARK/interpolation.py
+++ b/HARK/interpolation.py
@@ -14,7 +14,7 @@ import numpy as np
 from scipy.interpolate import CubicHermiteSpline
 from HARK.metric import MetricObject
 from HARK.rewards import CRRAutility, CRRAutilityP, CRRAutilityPP
-from numba import njit
+from HARK._numba import njit
 
 
 def _isscalar(x):

--- a/HARK/mat_methods.py
+++ b/HARK/mat_methods.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import numpy as np
-from numba import njit
+from HARK._numba import njit
 
 
 @njit

--- a/HARK/numba_tools.py
+++ b/HARK/numba_tools.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numba import njit
+from HARK._numba import njit
 
 from HARK.rewards import (
     CRRAutility_X,

--- a/HARK/simulator.py
+++ b/HARK/simulator.py
@@ -6,7 +6,7 @@ models from a human- and machine-readable model specification.
 from dataclasses import dataclass, field
 from copy import copy, deepcopy
 import numpy as np
-from numba import njit
+from HARK._numba import njit
 from sympy.utilities.lambdify import lambdify
 from sympy import symbols, IndexedBase
 from typing import Callable

--- a/HARK/utilities.py
+++ b/HARK/utilities.py
@@ -8,10 +8,12 @@ import cProfile
 import os
 import pstats
 import re
+import shutil
 
-import numba
 import numpy as np  # Python's numeric library, abbreviated "np"
 from scipy.interpolate import interp1d
+
+from HARK._numba import njit, prange
 
 from inspect import signature
 
@@ -546,7 +548,7 @@ def make_polynomial_params(coeffs, T, offset=0.0, step=1.0):
     return np.polyval(coeffs[::-1], X)
 
 
-@numba.njit
+@njit
 def jump_to_grid_1D(m_vals, probs, Dist_mGrid):  # pragma: nocover
     """
     Distributes values onto a predefined grid, maintaining the means.
@@ -601,7 +603,7 @@ def jump_to_grid_1D(m_vals, probs, Dist_mGrid):  # pragma: nocover
     return probGrid.flatten()
 
 
-@numba.njit
+@njit
 def jump_to_grid_2D(
     m_vals, perm_vals, probs, dist_mGrid, dist_pGrid
 ):  # pragma: nocover
@@ -718,7 +720,7 @@ def jump_to_grid_2D(
     return probGrid.flatten()
 
 
-@numba.njit(parallel=True)
+@njit(parallel=True)
 def gen_tran_matrix_1D(
     dist_mGrid, bNext, shk_prbs, perm_shks, tran_shks, LivPrb, NewBornDist
 ):  # pragma: nocover
@@ -760,7 +762,7 @@ def gen_tran_matrix_1D(
     """
 
     TranMatrix = np.zeros((len(dist_mGrid), len(dist_mGrid)))
-    for i in numba.prange(len(dist_mGrid)):
+    for i in prange(len(dist_mGrid)):
         mNext_ij = (
             bNext[i] / perm_shks + tran_shks
         )  # Compute next period's market resources given todays bank balances bnext[i]
@@ -771,7 +773,7 @@ def gen_tran_matrix_1D(
     return TranMatrix
 
 
-@numba.njit(parallel=True)
+@njit(parallel=True)
 def gen_tran_matrix_2D(
     dist_mGrid, dist_pGrid, bNext, shk_prbs, perm_shks, tran_shks, LivPrb, NewBornDist
 ):  # pragma: nocover
@@ -813,8 +815,8 @@ def gen_tran_matrix_2D(
     TranMatrix = np.zeros(
         (len(dist_mGrid) * len(dist_pGrid), len(dist_mGrid) * len(dist_pGrid))
     )
-    for i in numba.prange(len(dist_mGrid)):
-        for j in numba.prange(len(dist_pGrid)):
+    for i in prange(len(dist_mGrid)):
+        for j in prange(len(dist_pGrid)):
             mNext_ij = (
                 bNext[i] / perm_shks + tran_shks
             )  # Compute next period's market resources given todays bank balances bnext[i]
@@ -1151,11 +1153,9 @@ def test_latex_installation(pf):  # pragma: no cover
         otherwise ImportError raised to direct user to install latex manually
     """
     # Test whether latex is installed (some of the figures require it)
-    from distutils.spawn import find_executable
-
     latexExists = False
 
-    if find_executable("latex"):
+    if shutil.which("latex"):
         latexExists = True
         return True
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,16 +1,17 @@
-interpolation>=2.2.3
+interpolation>=2.2.3; sys_platform != 'emscripten'
 joblib>=1.2
 legacy-cgi; python_version >= '3.13'
 matplotlib>=3.6
 networkx>=3
-numba
+numba; sys_platform != 'emscripten'
 numpy
 optimagic
 pandas>=1.5
 pyyaml>=6.0
-quantecon
+quantecon; sys_platform != 'emscripten'
 scipy>=1.10
 seaborn>=0.12
 sequence-jacobian
 statsmodels>=0.14.2
+sympy
 xarray>=2023

--- a/tests/test_numba_shim.py
+++ b/tests/test_numba_shim.py
@@ -1,0 +1,162 @@
+"""
+This file implements unit tests for the optional-numba shim in HARK._numba.
+
+Two halves. The first exercises the fallback `njit` directly, by constructing it
+the way `HARK/_numba.py` does when numba is missing, so the calling conventions
+are covered on every run including CI where numba is installed. The second blocks
+numba with a meta-path finder and imports HARK in a subprocess, which is the only
+way to see the branch the browser actually takes.
+"""
+
+import importlib.util
+import inspect
+import subprocess
+import sys
+import textwrap
+import unittest
+
+from HARK import _numba
+from HARK.ConsumptionSaving.ConsIndShockModel import (
+    IndShockConsumerType,
+    PerfForesightConsumerType,
+)
+
+
+def _fallback_njit(*args, **kwargs):
+    """The no-op njit from HARK/_numba.py, duplicated so it can be tested directly.
+
+    Kept in sync by test_fallback_matches_shim_source below.
+    """
+    if args and callable(args[0]):
+        return args[0]
+    return lambda func: func
+
+
+def _double(x):
+    return 2 * x
+
+
+class TestFallbackNjitConventions(unittest.TestCase):
+    """Every calling convention HARK uses must return a working function."""
+
+    def test_bare_decorator(self):
+        self.assertEqual(_fallback_njit(_double)(21), 42)
+
+    def test_direct_call_with_kwargs(self):
+        # numba_tools.py builds CRRAutility and six relatives this way. A guard
+        # that also required "not kwargs" returns a decorator here, so the call
+        # would yield its own argument instead of raising.
+        self.assertEqual(_fallback_njit(_double, cache=True)(21), 42)
+
+    def test_direct_call_with_several_kwargs(self):
+        fn = _fallback_njit(_double, cache=True, error_model="numpy")
+        self.assertEqual(fn(21), 42)
+
+    def test_decorator_factory(self):
+        self.assertEqual(_fallback_njit(cache=True)(_double)(21), 42)
+
+    def test_decorator_factory_parallel(self):
+        self.assertEqual(_fallback_njit(parallel=True)(_double)(21), 42)
+
+    def test_signature_string_is_not_treated_as_a_function(self):
+        fn = _fallback_njit("float64(float64)", cache=True)(_double)
+        self.assertEqual(fn(21), 42)
+
+
+class TestShimExports(unittest.TestCase):
+    def test_exports_are_present(self):
+        for name in ("njit", "prange", "HAS_NUMBA"):
+            self.assertTrue(hasattr(_numba, name), f"HARK._numba lacks {name}")
+
+    def test_has_numba_matches_reality(self):
+        expected = importlib.util.find_spec("numba") is not None
+        self.assertEqual(_numba.HAS_NUMBA, expected)
+
+    def test_fallback_matches_shim_source(self):
+        """The duplicated fallback above must match HARK/_numba.py itself."""
+        source = inspect.getsource(_numba)
+        self.assertIn("if args and callable(args[0]):", source)
+        self.assertIn("return lambda func: func", source)
+
+
+class TestWithNumbaBlocked(unittest.TestCase):
+    """Import HARK in a subprocess with numba unavailable.
+
+    A subprocess is required because the check purges numba and HARK from
+    sys.modules; it cannot share an interpreter with the rest of the suite.
+    """
+
+    SCRIPT = textwrap.dedent(
+        """
+        import sys
+
+        class Blocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "numba" or fullname.startswith("numba."):
+                    # ModuleNotFoundError with .name set, matching what the
+                    # interpreter raises. Code that narrows on exc.name sees
+                    # the same thing here as on a platform without numba.
+                    raise ModuleNotFoundError(
+                        f"No module named {fullname!r}", name=fullname
+                    )
+                return None
+
+        for name in [m for m in sys.modules
+                     if m == "numba" or m.startswith(("numba.", "HARK"))]:
+            del sys.modules[name]
+        sys.meta_path.insert(0, Blocker())
+
+        # Rejection test: find_module was removed in 3.12, so a blocker written
+        # against it is inert and every assertion below would pass for nothing.
+        try:
+            import numba
+        except ImportError:
+            pass
+        else:
+            print("BLOCKER-INERT")
+            raise SystemExit(2)
+
+        from HARK import _numba
+        assert _numba.HAS_NUMBA is False, "HAS_NUMBA true while numba is blocked"
+        assert _numba.prange is range, "prange did not fall back to range"
+
+        from HARK.ConsumptionSaving.ConsIndShockModel import (
+            IndShockConsumerType,
+            PerfForesightConsumerType,
+        )
+        pf = PerfForesightConsumerType()
+        pf.solve()
+        ind = IndShockConsumerType()
+        ind.solve()
+        print(repr(float(pf.solution[0].cFunc(1.0))))
+        print(repr(float(ind.solution[0].cFunc(1.0))))
+        """
+    )
+
+    def test_hark_imports_and_solves_without_numba(self):
+        proc = subprocess.run(
+            [sys.executable, "-c", self.SCRIPT],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotIn("BLOCKER-INERT", proc.stdout, "the numba blocker did nothing")
+        self.assertEqual(proc.returncode, 0, f"stderr:\n{proc.stderr[-2000:]}")
+
+        without = [float(line) for line in proc.stdout.split()]
+
+        pf = PerfForesightConsumerType()
+        pf.solve()
+        ind = IndShockConsumerType()
+        ind.solve()
+        with_numba = [
+            float(pf.solution[0].cFunc(1.0)),
+            float(ind.solution[0].cFunc(1.0)),
+        ]
+
+        # Exact equality: the fallback runs the same pure-Python code numba
+        # compiles, so any difference is a real divergence rather than rounding.
+        self.assertEqual(without, with_numba)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Make numba optional so HARK imports in the browser (#1806)

Closes the Phase 1 and Phase 2 work in #1806. `import HARK` now succeeds where numba has
no build, which is the case on stock Pyodide and PyScript, and on any minimal install
without the compiled stack.

`HARK.core` reaches numba through three modules (`utilities.py`, `simulator.py`,
`SSJutils.py`), so the failure was total rather than a slowdown. This adds
`HARK/_numba.py`, a top-level guarded import that re-exports the real `njit` and `prange`
when numba is present and substitutes no-ops when it is not, and points the eight
numba-importing modules at it.

The shim I sketched in the issue turned out to be wrong, and wrong in the quiet way, so it
is worth a reviewer's attention. It guards on `callable(args[0]) and not kwargs`, which
handles the decorator forms but mishandles `njit(func, cache=True)`, the direct call that
`numba_tools.py:14-20` uses to build `CRRAutility` and six of its relatives. With keywords
present that guard declines the callable and hands back a decorator, so `CRRAutility`
becomes a function that takes a function, and `CRRAutility(c, rho)` returns `c` where it
should raise. The result is wrong numbers with a clean traceback-free run, which is the
failure mode I would least like to release into a solver. Callability of the first argument decides the
branch here and the keywords are irrelevant to it, so the guard tests callability alone; a
signature string is not callable and still reaches the factory branch, which is what that
form needs. All six calling conventions HARK uses are covered by tests.

`HARK/ConsumptionSaving/__init__.py` eagerly imports `ConsIndShockModelFast`, which
imports third-party `interpolation` and so pulls numba regardless of this shim. That
import is now guarded, so `import HARK.ConsumptionSaving` still succeeds, and constructing
a Fast type raises an error that states which packages are missing and why. Without this
the shim looks complete while `import HARK.ConsumptionSaving` still fails.

`requirements/base.txt` gains an environment marker on the three numba-implicated
packages: `numba`, `interpolation` and `quantecon`, each now carrying
`; sys_platform != 'emscripten'`. Under Pyodide `micropip` fails on numba before any
import is attempted, and markering numba alone is not enough, because `interpolation`
requires `numba>=0.59.1` and `quantecon` requires `numba>=0.49.0` and both reintroduce it
during resolution. Those two packages exist here only for `econforgeinterp`, `dcegm` and
`ConsIndShockModelFast`, which cannot run without numba anyway, so on a platform with no
numba they are dependencies for capability that cannot exist. On Linux, macOS and Windows
all three markers are inert and `pip install econ-ark` is unchanged, which preserves the
default install @llorracc asked to keep without the extras group discussed in the issue.

## Dependency defects this exposed

Markering `quantecon` out on emscripten removed a package that had been quietly supplying
someone else's dependency, and pulling that thread found two defects that have nothing to
do with browsers. This PR fixes both.

`sympy` was imported but never declared. `HARK/simulator.py` and `HARK/parser.py` import
it, `core.py` imports `simulator`, so `import HARK` has always needed it. It arrived
transitively through `quantecon`, which is its only supplier among the base dependencies.
Any install without `quantecon`, or a `quantecon` release that drops sympy, produces a
HARK that cannot be imported at all. `simulator.py:22` carries the comment
`# Prevent pre-commit from removing sympy`, so the import was already noticed once and
defended against the linter, at a layer that leaves the dependency undeclared.

`distutils` was already broken on every Python this package supports. `utilities.py`
called `from distutils.spawn import find_executable` inside `test_latex_installation`,
and `distutils` was removed in Python 3.12 while the classifiers claim 3.12, 3.13 and
3.14. Now `shutil.which`, which is the documented replacement. Verified by calling
`test_latex_installation(determine_platform())` on 3.13, where it returns `True` and
previously raised `ModuleNotFoundError`. No test covers this path.

Three modules stay unavailable in the browser, by design and per Phase 4:
`econforgeinterp`, `dcegm`, and `ConsIndShockModelFast`. Each needs `interpolation` or
`quantecon`, which import numba themselves. Nothing on the core path reaches them, and
`ConsIndShockModel` imports neither.

## Tests and CI (added after Copilot's review)

`tests/test_numba_shim.py` exercises each `njit` calling convention HARK uses, the direct
call above among them, and asserts the duplicated fallback in the test still matches
`HARK/_numba.py`. A subprocess test blocks numba with a meta-path finder and checks that
both models solve to values exactly equal to the numba run. It carries its own rejection
test, since `find_module` was removed in 3.12 and a blocker written against it is inert.

A `no-numba` job in `hark.yml` uninstalls `numba`, `interpolation` and `quantecon`, then
asserts numba is unimportable before running the suite. Without that assertion a failed
uninstall would leave the job passing while testing nothing. Measured locally in a
matching environment, 821 tests pass; the 49 difference from 870 is the four
numba-dependent test files the job skips.

Copilot also flagged the guard in `ConsumptionSaving/__init__.py` as too broad, correctly.
It now re-raises unless `exc.name` is one of the three optional packages, so an
`ImportError` from a bug inside the Fast module is no longer reported as a missing
dependency.

## Verification

- Full suite green with numba present: 870 passed.
- With numba blocked by a `find_spec` meta-path finder, `import HARK` succeeds and both
  `PerfForesightConsumerType` and `IndShockConsumerType` solve to values exactly equal to
  the numba run. The blocker carries a rejection test, because the legacy `find_module`
  protocol is a no-op on Python 3.12 and later and would otherwise yield a false pass.
- Executed in a real browser on both wasm kernels, driving the built site with Playwright
  and reading rendered cell output. Each run carries rejection tests that must fail, since
  an earlier version of the harness reported a `BadZipFile` traceback as a pass.

  | | native CPython | JupyterLite + xeus (numba) | stock Pyodide (no numba) |
  |---|---|---|---|
  | PerfForesight `cFunc(1.0)` | `1.0127134424479616` | `1.0127134424479616` | `1.0127134424479616` |
  | IndShock `cFunc(1.0)` | `0.9355212539489954` | `0.9355212539489954` | `0.9355212539489954` |
  | `import HARK` | | 12.3s | 10.4s |
  | IndShock solve | 0.004s | 0.02s | 0.01s |

  On Pyodide `HAS_NUMBA` is `False` and `prange is range`, so the shim is what carries it.
  The interpreted solve takes 0.01s against 0.004s native, because these models spend
  their time in NumPy rather than in the `njit` loops.

## Ask

@mnwhite a review, and if this looks right, a 0.17.3 release. econ-ark/DemARK is migrating
off Binder to in-browser execution and resolves HARK from PyPI, so merging alone does not
reach it. The release is what unblocks that work.
