### PR TITLE
Simulate time-varying MrkvArray and Rfree at the solver's timing

### DIFF
--- a/HARK/ConsumptionSaving/ConsMarkovModel.py
+++ b/HARK/ConsumptionSaving/ConsMarkovModel.py
@@ -1049,10 +1049,12 @@ class MarkovConsumerType(IndShockConsumerType):
         # warning per element of T_cycle when pLvl is missing.
         pLvl_prev = resolve_balanced_sort_key(self)
 
-        # Draw new Markov states for each agent
+        # Agents with t_cycle == t are entering period t, so they move by
+        # MrkvArray[t - 1], the matrix the solver used for t - 1 -> t (as
+        # get_shocks reads IncShkDstn[t - 1]). At t == 0 the index wraps.
         for t in range(self.T_cycle):
             markov_process = MarkovProcess(
-                self.MrkvArray[t], seed=self.RNG.integers(0, 2**31 - 1)
+                self.MrkvArray[t - 1], seed=self.RNG.integers(0, 2**31 - 1)
             )
             right_age = self.t_cycle == t
             # Sorting by pLvl systematically samples the agents chosen for
@@ -1204,7 +1206,9 @@ class MarkovConsumerType(IndShockConsumerType):
         RfreeNow = np.zeros(self.AgentCount)
         for t in range(self.T_cycle):
             these = self.t_cycle == t
-            RfreeNow[these] = self.Rfree[t][self.shocks["Mrkv"][these]]
+            # Rfree[t - 1] is the return the solver applied to assets saved in
+            # period t - 1, which agents with t_cycle == t now receive.
+            RfreeNow[these] = self.Rfree[t - 1][self.shocks["Mrkv"][these]]
         return RfreeNow
 
     def get_controls(self):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ Release Date: TBD
 
 #### Minor Changes
 
+- Fixes `MarkovConsumerType` simulating a time-varying `MrkvArray` or `Rfree` one period ahead of its solution: `get_markov_states` drew with `MrkvArray[t]` and `get_Rport` paid `Rfree[t]` to agents entering period `t`, where the solver uses index `t - 1` for that move (as `get_shocks` already does for `IncShkDstn` and `PermGroFac`). Invisible whenever both are time-invariant.
 - Fixes `HARK.dual_measure` indexing the Q income process one period ahead of P whenever `cycles != 1`: `_draw_Q_shocks_indshock` chose `IncShkDstn_Q[t]` where `get_shocks` uses `IncShkDstn[t - 1]`, so an infinite-horizon agent with `T_cycle > 1` drew the Q sample from the wrong period's distribution and scaled it by the wrong `PermGroFac`. Invisible until now because every fixture used `T_cycle == 1`, where indices 0 and -1 name the same element.
 - Fixes `MarkovProcess.draw(shuffle=True)` returning uninitialized memory for an agent whose source state has no row in the transition matrix. The output buffer is now sentinel-filled and verified, so those agents raise `IndexError` (as the unshuffled path already did) instead of silently inheriting the previous period's `Mrkv` values.
 - Fixes a division by zero at `LivPrb == 1` in `compute_mean_pLvl`, and a wrong limit in the corresponding guard in `compute_pLvl_factor`. Both compute the newborn share of a stationary population; it is now one shared helper returning `1 / T_age` at the no-mortality limit rather than `nan` or `0`.

--- a/tests/ConsumptionSaving/test_ConsMarkovModel.py
+++ b/tests/ConsumptionSaving/test_ConsMarkovModel.py
@@ -366,3 +366,73 @@ class testDeathShuffleMarkov(unittest.TestCase):
 
     def test_death_shuffle_default_false(self):
         self.assertFalse(MarkovConsumerType().death_shuffle)
+
+
+class testTimeVaryingSimulationTiming(unittest.TestCase):
+    """The simulator must use the period-(t - 1) MrkvArray and Rfree that the
+    solver used for the move from t - 1 to t, as it already does for
+    IncShkDstn and PermGroFac. Both are invisible when they are constant."""
+
+    T = 4
+
+    def _make_agent(self, MrkvArray, Rfree, cycles=1):
+        atom = DiscreteDistributionLabeled(
+            pmv=np.array([1.0]),
+            atoms=np.array([[1.0], [1.0]]),
+            var_names=["PermShk", "TranShk"],
+        )
+        params = deepcopy(init_indshk_markov)
+        params["constructors"] = dict(params["constructors"])
+        params["constructors"]["IncShkDstn"] = None
+        params["constructors"]["MrkvArray"] = None
+        T_cycle = len(MrkvArray)
+        params.update(
+            cycles=cycles,
+            T_cycle=T_cycle,
+            MrkvArray=MrkvArray,
+            IncShkDstn=[[atom, atom] for _ in range(T_cycle)],
+            Rfree=[np.array([R, R]) for R in Rfree],
+            LivPrb=[np.ones(2) for _ in range(T_cycle)],
+            PermGroFac=[np.ones(2) for _ in range(T_cycle)],
+            MrkvPrbsInit=np.array([1.0, 0.0]),
+            kLogInitMean=np.log(5.0),
+            AgentCount=3,
+            T_sim=self.T,
+            T_age=None,
+        )
+        agent = MarkovConsumerType(**params)
+        agent.solve()
+        return agent
+
+    def test_markov_transition_timing(self):
+        # Only MrkvArray[2] moves state 0 to state 1: the solver applies it
+        # between periods 2 and 3, so agents must switch entering period 3.
+        MrkvArray = [np.eye(2) for _ in range(self.T)]
+        MrkvArray[2] = np.array([[0.0, 1.0], [0.0, 1.0]])
+        agent = self._make_agent(MrkvArray, [1.02] * self.T)
+        agent.track_vars = ["Mrkv"]
+        agent.initialize_sim()
+        agent.simulate()
+        np.testing.assert_array_equal(agent.history["Mrkv"][:, 0], [0, 0, 0, 1])
+
+    def test_markov_transition_timing_cyclical(self):
+        # Infinite horizon with T_cycle = 2: MrkvArray[1] governs the move from
+        # period 1 back to period 0, so agents switch entering period 0 (t = 2).
+        MrkvArray = [np.eye(2), np.array([[0.0, 1.0], [0.0, 1.0]])]
+        agent = self._make_agent(MrkvArray, [1.02, 1.02], cycles=0)
+        agent.track_vars = ["Mrkv"]
+        agent.initialize_sim()
+        agent.simulate()
+        np.testing.assert_array_equal(agent.history["Mrkv"][:, 0], [0, 0, 1, 1])
+
+    def test_rfree_timing(self):
+        Rfree = [1.01 + 0.01 * t for t in range(self.T)]
+        agent = self._make_agent([np.eye(2) for _ in range(self.T)], Rfree)
+        agent.track_vars = ["aNrm", "mNrm", "TranShk", "PermShk"]
+        agent.initialize_sim()
+        agent.simulate()
+        h = agent.history
+        for s in range(1, self.T):
+            implied = (h["mNrm"][s] - h["TranShk"][s]) * h["PermShk"][s]
+            implied /= h["aNrm"][s - 1]
+            np.testing.assert_allclose(implied, Rfree[s - 1], rtol=1e-12)


### PR DESCRIPTION
Fixes #1820.

`MarkovConsumerType` simulated a time-varying `MrkvArray` or `Rfree` one period ahead of its solution. For agents entering period `t`, `get_markov_states` drew with `MrkvArray[t]` and `get_Rport` paid `Rfree[t]`, while the solver uses index `t - 1` for that move and `get_shocks` already reads `IncShkDstn[t - 1]` and `PermGroFac[t - 1]`. This PR changes those two indices to `t - 1`. At `t == 0` the index wraps to the last period, as `IncShkDstn[t - 1]` already does. In a cyclical problem with `T_cycle > 1`, `MrkvArray[-1]` is the transition matrix for the move from the last period back to period 0.

When `MrkvArray` and `Rfree` are time-invariant, simulations match `main` exactly. The existing tests pass unchanged. The seed draws happen in the same order, so simulated values move only where `MrkvArray[t - 1]` or `Rfree[t - 1]` differs from index `t`.

New tests in `testTimeVaryingSimulationTiming` (`tests/ConsumptionSaving/test_ConsMarkovModel.py`), each of which fails on `main`:

- a switch placed only in `MrkvArray[2]` moves agents entering period 3 (on `main` they move entering period 2);
- in an infinite-horizon problem with `T_cycle = 2`, a switch in `MrkvArray[1]` moves agents entering period 0 of the next cycle (on `main`, entering period 1);
- with `Rfree[t] = 1.01 + 0.01 t`, the return implied by the simulated history, `(mNrm - TranShk) * PermShk / aNrm_prev`, equals `Rfree[s - 1]`.

The other Markov draws are unaffected. `AggIndMrkvConsumerType.get_markov_states` falls back to the fixed parent method when `_hierarchical` is False. Its hierarchical draw (`AggIndMrkvConsumerType.get_micro_markov_states`) and `KrusellSmithType.get_micro_markov_states` read time-invariant `CondMrkvArrays` and permutation arrays.

The full test suite (873 passed, 29 subtests) and the pre-commit hooks on the changed files pass locally.
